### PR TITLE
adopted original issue changes for use in the filter layout branch

### DIFF
--- a/components/scorecards/PerformanceScoreCard.jsx
+++ b/components/scorecards/PerformanceScoreCard.jsx
@@ -12,7 +12,7 @@ import SimpleMenu from '~/components/SimpleMenu';
 import InfoIcon from '@material-ui/icons/Info';
 import IconButton from '@material-ui/core/IconButton';
 import Dropdown from '~/components/Dropdown';
-import SimpleScoreCardHeader from '~/components/SimpleScoreCardHeader';
+import ScoreCardHeader from '~/components/scorecards/ScoreCardHeader';
 
 
 const styles = theme => ({
@@ -67,7 +67,7 @@ const arrivalWindows = [
   }
 ];
 
-class ScoreCard extends Component {
+class PerformanceScoreCard extends Component {
   constructor(props) {
     super(props);
     this.handleMenuChange = this.handleMenuChange.bind(this);
@@ -119,7 +119,7 @@ class ScoreCard extends Component {
             </Fragment>
           )}/>
         </div>
-        <SimpleScoreCardHeader title="On-Time Performance" />
+        <ScoreCardHeader title="On-Time Performance" />
         <Grid container item justify="center" alignItems="center" xs={12} className={ classes.cardContainer }>
           <Grid item xs={12} md={4} className={ classes.maxWidth300 }>
             <OnTimePie bins={data.ontime} total={data.total_arrivals_analyzed} selected={this.state.selectedArrivalWindow.dataLabel}/>
@@ -138,4 +138,4 @@ class ScoreCard extends Component {
 
 }
 
-export default withStyles(styles)(ScoreCard);
+export default withStyles(styles)(PerformanceScoreCard);

--- a/components/scorecards/ScoreCard.jsx
+++ b/components/scorecards/ScoreCard.jsx
@@ -1,0 +1,93 @@
+import React, { Fragment} from 'react';
+import {
+  Typography,
+  Card,
+  CardMedia,
+  Grid,
+  Divider
+} from '@material-ui/core';
+import { withStyles } from '@material-ui/core/styles';
+import { linesById } from '~/helpers/LineInfo.js';
+import Circle from '~/components/Circle';
+import TooltipCustom from '~/components/TooltipCustom';
+import ScoreCardHeader from '~/components/scorecards/ScoreCardHeader';
+
+const styles = theme => ({
+  root: {
+    //padding: theme.spacing.unit * 2,
+    padding: 0,
+    textAlign: 'center',
+    color: theme.palette.text.secondary,
+    position: 'relative',
+    height: '100%'
+  },
+  iconPosition: {
+    position: 'absolute',
+    top: 0,
+    right: 0
+  },
+  performer: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexDirection: 'row',
+    marginBottom: 10
+  },
+  container: {
+    height: 'calc(100% - 3em)'
+  },
+  separator: {
+    margin: 10
+  }
+});
+
+const ScoreCard = (props) => {
+  const { classes, headerText, title, tooltip, blockA, blockB, blockC } = props;
+  return (
+    <Card elevation={1} classes={classes}>
+      <div className={ classes.iconPosition }>
+        <TooltipCustom title={(<Fragment>
+            <Typography color="inherit">{tooltip.header}</Typography>
+            {tooltip.content}
+          </Fragment>
+        )}/>
+      </div>
+      <ScoreCardHeader title={headerText} />
+      <Grid container justifyContent="center" alignItems="center" className={ classes.separator }>
+        <Grid item xs={12} className={ classes.separator }>
+          <Typography variant={props.width === 'xs'
+            ? 'h3'
+            : 'h2'} component="p" align="center">
+          {title}
+          </Typography>
+          <Divider light variant="middle" className={ classes.separator } />
+        </Grid>
+        {blockA && (
+          <Grid item xs={12}>
+            <Typography color="textPrimary" gutterBottom>
+              {blockA}
+            </Typography>
+          </Grid>
+        )}
+        {blockB && (
+            <Grid item xs={12} className={ classes.separator }>
+            <Divider light variant="middle" className={ classes.separator } />
+            <Typography color="textPrimary" gutterBottom>
+              {blockB}
+            </Typography>
+          </Grid>
+        )}
+        {blockC && (
+            <Grid item xs={12} className={ classes.separator }>
+            <Divider light variant="middle" className={ classes.separator } />
+            <Typography color="textPrimary" gutterBottom>
+              {blockC}
+            </Typography>
+          </Grid>
+        )}
+      </Grid>
+    </Card>
+  );
+};
+
+export default withStyles(styles)(ScoreCard);

--- a/components/scorecards/ScoreCardHeader.jsx
+++ b/components/scorecards/ScoreCardHeader.jsx
@@ -16,7 +16,7 @@ const styles = theme => ({
   }
 });
 
-const SimpleScoreCardHeader = (props) => {
+const ScoreCardHeader = (props) => {
   const { title, classes } = props;
   return (
     <CardHeader classes={ classes } title={ title }>
@@ -24,5 +24,5 @@ const SimpleScoreCardHeader = (props) => {
   )
 }
 
-export default withStyles(styles)(SimpleScoreCardHeader);
+export default withStyles(styles)(ScoreCardHeader);
 

--- a/components/scorecards/WaitTimeScoreCard.jsx
+++ b/components/scorecards/WaitTimeScoreCard.jsx
@@ -10,7 +10,7 @@ import { withStyles } from '@material-ui/core/styles';
 import { linesById } from '~/helpers/LineInfo.js';
 import Circle from '~/components/Circle';
 import TooltipCustom from '~/components/TooltipCustom';
-import SimpleScoreCardHeader from '~/components/SimpleScoreCardHeader';
+import ScoreCardHeader from '~/components/scorecards/ScoreCardHeader';
 
 const styles = theme => ({
   root: {
@@ -41,7 +41,7 @@ const styles = theme => ({
   }
 });
 
-const SimpleScoreCard = (props) => {
+const WaitTimeScoreCard = (props) => {
   const { data, classes } = props;
   return (
     <Card elevation={1} classes={classes}>
@@ -52,7 +52,7 @@ const SimpleScoreCard = (props) => {
           </Fragment>
         )}/>
       </div>
-      <SimpleScoreCardHeader title="Average Wait Time" />
+      <ScoreCardHeader title="Average Wait Time" />
       <Grid container justifyContent="center" alignItems="center" className={ classes.separator }>
         <Grid item xs={6}>
           <img
@@ -107,4 +107,4 @@ const SimpleScoreCard = (props) => {
   );
 };
 
-export default withStyles(styles)(SimpleScoreCard);
+export default withStyles(styles)(WaitTimeScoreCard);

--- a/pages/index/index.jsx
+++ b/pages/index/index.jsx
@@ -19,8 +19,8 @@ import SimpleMenu from '~/components/SimpleMenu';
 import { lines } from '~/helpers/LineInfo';
 import { whenListAllObjects, whenGotS3Object } from '~/helpers/DataFinder';
 import LogoAndTitle from '~/components/LogoAndTitle';
-import ScoreCard from '~/components/ScoreCard';
-import SimpleScoreCard from '~/components/SimpleScoreCard';
+import PerformanceScoreCard from '~/components/scorecards/PerformanceScoreCard';
+import WaitTimeScoreCard from '~/components/scorecards/WaitTimeScoreCard';
 import FilterPanel from '~/components/FilterPanel';
 import CONFIG from '~/config';
 import LineComparison from '~/components/LineComparison';
@@ -109,12 +109,12 @@ class Index extends Component {
                 dates={["Today", "Yesterday"]}
                 handleDate={ this.handleDate }
               />
+            </Grid>            
+            <Grid item xs={12} md={5} classes={ classes }>
+              <PerformanceScoreCard data={ latestData } width={ this.props.width } />
             </Grid>
             <Grid item xs={12} md={5} classes={ classes }>
-              <ScoreCard data={ latestData } width={ this.props.width } />
-            </Grid>
-            <Grid item xs={12} md={5} classes={ classes }>
-              <SimpleScoreCard width={this.props.width} data={ latestData }/>
+              <WaitTimeScoreCard width={this.props.width} data={ latestData }/>
             </Grid>
             <Grid item xs={12} md={12}>
               <LineComparison formattedData={formattedLineData} allLineData={allLineData}/>

--- a/pages/line/TrainStats.jsx
+++ b/pages/line/TrainStats.jsx
@@ -7,8 +7,8 @@ import {withStyles} from '@material-ui/core/styles';
 import withWidth from '@material-ui/core/withWidth';
 import flowRight from 'lodash/flowRight';
 import LogoAndTitle from '~/components/LogoAndTitle';
-import ScoreCard from '~/components/ScoreCard';
-import SimpleScoreCard from '~/components/SimpleScoreCard';
+import PerformanceScoreCard from '~/components/scorecards/PerformanceScoreCard';
+import WaitTimeScoreCard from '~/components/scorecards/WaitTimeScoreCard';
 import LineSelector from '~/components/LineSelector';
 import DiagramLink from '~/components/DiagramLink';
 
@@ -32,11 +32,11 @@ const TrainStats = (props) => {
         </Grid>
         <Grid container item spacing={16} xs={12} lg={8} justify="space-between" alignItems="center">
           <Grid item xs={12} md={6}>
-            <ScoreCard data={ data } width={ props.width } />
+            <PerformanceScoreCard data={ data } width={ props.width } />
           </Grid>
           <Grid container item xs={12} md={5}>
             <Grid item xs={12}>
-              <SimpleScoreCard width={props.width} data={ data }/>
+              <WaitTimeScoreCard width={props.width} data={ data }/>
             </Grid>
             <Hidden smDown>
               <Grid item xs={12} className={ classes.spaceTop }>


### PR DESCRIPTION
Redid original changes to the the scorecards but inside of the filter_layout branch. New directory created for scorecards. ScoreCard.jsx now accepts up to 3 text blocks and allows a placeholder card to be used that can display information. It wasn't created to be "future proof", more of a tool to be used. I continued on with the names that I picked.