### PR TITLE
Reimplent linter and clean up error logs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,10 @@
 module.exports = {
-  "extends": "airbnb",
-  "parser": "babel-eslint"
+  extends: 'airbnb',
+  parser: 'babel-eslint',
+  rules: {
+    'react/prop-types': [0],
+    'react/forbid-prop-types': [0],
+    'import/no-unresolved': [0],
+    'comma-dangle': [1],
+  }
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,4 @@
 module.exports = {
-    "extends": "airbnb",
-    "parser": "babel-eslint"
+  "extends": "airbnb",
+  "parser": "babel-eslint"
 };

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is the front end React App for our performance monitor tool.
 ```
 git clone https://github.com/metro-ontime/frontend.git
 cd frontend
-npm i
+yarn
 ```
 2. To run live development server: Run the railstats api https://github.com/metro-ontime/railstats_api and then `npm run dev`
 3. To build and export static web app to 'out' directory without a local API:
@@ -22,3 +22,10 @@ npm run export
 
 We use ESLint with the AirBnB javascript/react Style Guide, available here:
 https://github.com/airbnb/javascript/tree/master/react
+
+Linting is run with
+```
+npm start
+npm run build
+npm run lint
+```

--- a/components/Circle.jsx
+++ b/components/Circle.jsx
@@ -14,7 +14,7 @@ const Circle = (props) => {
         float: 'left',
       }}
     />
-  )
-}
+  );
+};
 
 export default Circle;

--- a/components/CircularIndeterminate.jsx
+++ b/components/CircularIndeterminate.jsx
@@ -6,7 +6,7 @@ import CircularProgress from '@material-ui/core/CircularProgress';
 const styles = {
   root: {
     flexGrow: 1,
-  }
+  },
 };
 
 function CircularIndeterminate(props) {

--- a/components/DataParser.jsx
+++ b/components/DataParser.jsx
@@ -1,16 +1,32 @@
 import React, { Component } from 'react';
 import Highchart from './charts/Highchart';
 import LinearIndeterminate from './LinearIndeterminate';
-import { prepareObservations, prepareSchedule } from '../helpers/PrepareData';
-import { whenListAllObjects, whenGotS3Object } from '../helpers/DataFinder';
+import { prepareObservations, prepareSchedule } from '~/helpers/PrepareData';
 
 class DataParser extends Component {
   constructor(props) {
     super(props);
-    this.state = { trips: null, schedule: null, minTime: null, maxTime: null };
+    this.state = {
+      trips: null, schedule: null, minTime: null, maxTime: null,
+    };
     this.updateTrips = this.updateTrips.bind(this);
     this.updateSchedule = this.updateSchedule.bind(this);
     this.fetchData = this.fetchData.bind(this);
+  }
+
+  componentDidMount() {
+    const { line, date } = this.props;
+    this.fetchData(line, date);
+  }
+
+  componentDidUpdate(prevProps) {
+    const { date, line } = this.props;
+    if (date !== prevProps.date || line !== prevProps.line) {
+      this.setState({
+        trips: null, schedule: null, minTime: null, maxTime: null,
+      });
+      this.fetchData(line, date);
+    }
   }
 
   fetchData(line, date) {
@@ -21,32 +37,44 @@ class DataParser extends Component {
     prepareSchedule(schedulePath, line, this.updateSchedule);
   }
 
-  componentDidMount() {
-    this.fetchData(this.props.line, this.props.date)
-  }
-
-  componentDidUpdate(prevProps) {
-    if (this.props.date !== prevProps.date || this.props.line !== prevProps.line) {
-      this.setState({ trips: null, schedule: null, minTime: null, maxTime: null });
-      this.fetchData(this.props.line, this.props.date);
-    }
-  }
-
   updateTrips(trips0, trips1) {
     this.setState({ trips: [trips0, trips1] });
   }
 
   updateSchedule(trips0, trips1, minTime, maxTime) {
-    this.setState({ schedule: [trips0, trips1], minTime: minTime, maxTime: maxTime });
+    this.setState({ schedule: [trips0, trips1], minTime, maxTime });
   }
 
   render() {
+    const {
+      trips,
+      schedule,
+      minTime,
+      maxTime
+    } = this.state;
+    const { direction, line } = this.props;
     return (
       <div>
-        {this.state.trips && this.state.schedule ? (
+        {trips && schedule ? (
           <div>
-            {this.props.direction == 0 && <Highchart observations={this.state.trips[0].concat(this.state.schedule[0])} min={this.state.minTime} max={this.state.maxTime} direction={ 0 } line={ this.props.line }/>}
-            {this.props.direction == 1 && <Highchart observations={this.state.trips[1].concat(this.state.schedule[1])} min={this.state.minTime} max={this.state.maxTime} direction={ 1 } line={ this.props.line }/>}
+            {direction === 0 && (
+              <Highchart
+                observations={trips[0].concat(schedule[0])}
+                min={minTime}
+                max={maxTime}
+                direction={0}
+                line={line}
+              />
+            )}
+            {direction === 1 && (
+              <Highchart
+                observations={trips[1].concat(schedule[1])}
+                min={minTime}
+                max={maxTime}
+                direction={1}
+                line={line}
+              />
+            )}
           </div>
         ) : (
           <LinearIndeterminate />

--- a/components/DataParser.jsx
+++ b/components/DataParser.jsx
@@ -19,12 +19,12 @@ class DataParser extends Component {
     this.fetchData(line, date);
   }
 
-  componentDidUpdate(prevProps) {
+  componentWillUpdate(prevProps) {
     const { date, line } = this.props;
     if (date !== prevProps.date || line !== prevProps.line) {
-      this.setState({
-        trips: null, schedule: null, minTime: null, maxTime: null,
-      });
+      // this.setState({
+      //   trips: null, schedule: null, minTime: null, maxTime: null,
+      // });
       this.fetchData(line, date);
     }
   }
@@ -50,7 +50,7 @@ class DataParser extends Component {
       trips,
       schedule,
       minTime,
-      maxTime
+      maxTime,
     } = this.state;
     const { direction, line } = this.props;
     return (

--- a/components/DiagramLink.jsx
+++ b/components/DiagramLink.jsx
@@ -1,35 +1,37 @@
-import React, {Fragment} from 'react';
+import React from 'react';
 import {
   Button,
   Card,
   CardContent,
-  Typography
+  Typography,
 } from '@material-ui/core';
-import {withStyles} from '@material-ui/core/styles';
-import { linesById } from '~/helpers/LineInfo.js';
+import { withStyles } from '@material-ui/core/styles';
+import { linesById } from '~/helpers/LineInfo';
 
-const styles = theme => ({
+const styles = () => ({
   padding: {
-    padding: '0.5em'
-  }
+    padding: '0.5em',
+  },
 });
 
 const DiagramLink = (props) => {
-  const { classes } = props;
+  const { classes, line, action } = props;
   return (
     <Card>
       <CardContent>
-        <Typography variant="body2" align="center" className={ classes.padding }>
+        <Typography variant="body2" align="center" className={classes.padding}>
           View today's Marey Diagram
         </Typography>
-        <Typography variant="h5" align="center" className={ classes.padding }>
-          <Button variant="outlined" onClick={ () => { props.action({}, 1) } }>
-            { linesById[props.line]["name"] } Line Visualizer
+        <Typography variant="h5" align="center" className={classes.padding}>
+          <Button variant="outlined" onClick={() => { action({}, 1); }}>
+            { linesById[line].name }
+            {' '}
+Line Visualizer
           </Button>
         </Typography>
       </CardContent>
     </Card>
-  )
-}
+  );
+};
 
 export default withStyles(styles)(DiagramLink);

--- a/components/DiagramLink.jsx
+++ b/components/DiagramLink.jsx
@@ -20,7 +20,7 @@ const DiagramLink = (props) => {
     <Card>
       <CardContent>
         <Typography variant="body2" align="center" className={classes.padding}>
-          View today's Marey Diagram
+          View today&#39;s Marey Diagram
         </Typography>
         <Typography variant="h5" align="center" className={classes.padding}>
           <Button variant="outlined" onClick={() => { action({}, 1); }}>

--- a/components/Dropdown.jsx
+++ b/components/Dropdown.jsx
@@ -5,18 +5,18 @@ import MenuItem from '@material-ui/core/MenuItem';
 import { withStyles } from '@material-ui/core/styles';
 import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
 
-const styles = theme => ({
+const styles = () => ({
   button: {
     display: 'flex',
     justifyContent: 'space-between',
     alignItems: 'center',
-    width: '100%'
+    width: '100%',
   },
   icon: {
     marginTop: '0.25em',
     marginLeft: '1em',
     fontSize: 32,
-  }
+  },
 });
 
 class Dropdown extends Component {
@@ -27,23 +27,29 @@ class Dropdown extends Component {
     };
   }
 
-  handleClick = event => {
+  handleClick = (event) => {
     this.setState({ anchorEl: event.currentTarget });
   };
 
   handleClose = (item, index) => {
+    const { menuItems, handleMenuChange } = this.props;
     this.setState({ anchorEl: null });
-    if (this.props.menuItems.includes(item)) {
-      this.props.handleMenuChange(item, index);
+    if (menuItems.includes(item)) {
+      handleMenuChange(item, index);
     }
   };
 
   render() {
     const { anchorEl } = this.state;
-    const { classes } = this.props;
-    const menuItems = this.props.menuItems.map((item, index) => {
-      return <MenuItem onClick={() => this.handleClose(item, index)} key={item}>{ item }</MenuItem>
-    });
+    const { classes, menuItems, selected } = this.props;
+    const menuItemList = menuItems.map((item, index) => (
+      <MenuItem
+        onClick={() => this.handleClose(item, index)}
+        key={item}
+      >
+        { item }
+      </MenuItem>
+    ));
     return (
       <Fragment>
         <Button
@@ -51,13 +57,13 @@ class Dropdown extends Component {
           aria-haspopup="true"
           variant="outlined"
           onClick={this.handleClick}
-          className={ classes.button }
+          className={classes.button}
         >
           <div>
-            { this.props.menuItems[this.props.selected] }
+            { menuItems[selected] }
           </div>
           <div>
-            <KeyboardArrowDownIcon className={ classes.icon }/>
+            <KeyboardArrowDownIcon className={classes.icon} />
           </div>
         </Button>
         <Menu
@@ -66,7 +72,7 @@ class Dropdown extends Component {
           open={Boolean(anchorEl)}
           onClose={this.handleClose}
         >
-          { menuItems }
+          { menuItemList }
         </Menu>
       </Fragment>
     );

--- a/components/FilterPanel.jsx
+++ b/components/FilterPanel.jsx
@@ -66,8 +66,8 @@ const FilterPanel = (props) => {
     dates,
     handleDate,
   } = props;
-  const windows = arrivalWindows.map((item, i) => (
-    <MenuItem value={item.dataLabel} key={i}>
+  const windows = arrivalWindows.map(item => (
+    <MenuItem value={item.dataLabel} key={item.dataLabel}>
       { item.menuLabel }
     </MenuItem>
   ));
@@ -83,8 +83,8 @@ const FilterPanel = (props) => {
       </div>
     </MenuItem>
   ));
-  const dateSelectors = dates.map((item, i) => (
-    <MenuItem value={item} key={i}>
+  const dateSelectors = dates.map(item => (
+    <MenuItem value={item} key={item}>
       { item }
     </MenuItem>
   ));

--- a/components/FilterPanel.jsx
+++ b/components/FilterPanel.jsx
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react';
+import React from 'react';
 import {
   FormControl,
   InputLabel,
@@ -11,13 +11,13 @@ import {
   Avatar,
 } from '@material-ui/core';
 import { withStyles } from '@material-ui/core/styles';
-import { lines, linesByName } from '../helpers/LineInfo.js';
+import { lines } from '~/helpers/LineInfo';
 
 const styles = theme => ({
   avatar: {
     height: 25,
     width: 25,
-    marginRight: 10
+    marginRight: 10,
   },
   selectEmpty: {
     marginTop: theme.spacing.unit * 2,
@@ -33,121 +33,111 @@ const styles = theme => ({
   formControl: {
     margin: theme.spacing.unit,
     width: 120,
-  }
+  },
 });
 
 const arrivalWindows = [
   {
     menuLabel: '1 minute',
-    dataLabel: '1_min'
+    dataLabel: '1_min',
   }, {
     menuLabel: '2 minutes',
-    dataLabel: '2_min'
+    dataLabel: '2_min',
   }, {
     menuLabel: '3 minutes',
-    dataLabel: '3_min'
+    dataLabel: '3_min',
   }, {
     menuLabel: '4 minutes',
-    dataLabel: '4_min'
+    dataLabel: '4_min',
   }, {
     menuLabel: '5 minutes',
-    dataLabel: '5_min'
-  }
+    dataLabel: '5_min',
+  },
 ];
 
-class FilterPanel extends Component {
-  constructor(props) {
-    super(props)
-  }
-
-  render() {
-    const {
-      classes,
-      line,
-      handleLineChange,
-      arrivalWindow,
-      handleArrivalWindow,
-      date,
-      dates,
-      handleDate
-    } = this.props;
-    const windows = arrivalWindows.map((item, i) => {
-      return (
-        <MenuItem value={item.dataLabel} key={i}>
-          { item.menuLabel }
-        </MenuItem>
-      )
-    });
-		const lineSelectors = lines.map((metLine,i) => (
-      <MenuItem value={`${metLine.name}`} key={i}>
-        <div style={{display: "flex", alignItems: "center"}}>
+const FilterPanel = (props) => {
+  const {
+    classes,
+    line,
+    handleLineChange,
+    arrivalWindow,
+    handleArrivalWindow,
+    date,
+    dates,
+    handleDate,
+  } = props;
+  const windows = arrivalWindows.map((item, i) => (
+    <MenuItem value={item.dataLabel} key={i}>
+      { item.menuLabel }
+    </MenuItem>
+  ));
+  const lineSelectors = lines.map(metLine => (
+    <MenuItem value={`${metLine.name}`} key={metLine.name}>
+      <div style={{ display: 'flex', alignItems: 'center' }}>
         <ListItemAvatar>
-          <Avatar className={ classes.avatar }>
-            <div style={{ backgroundColor: metLine.color, }} className={ classes.lineDot} />
+          <Avatar className={classes.avatar}>
+            <div style={{ backgroundColor: metLine.color }} className={classes.lineDot} />
           </Avatar>
         </ListItemAvatar>
         {metLine.name}
-        </div>
-      </MenuItem>
-	  ));
-    const dateSelectors = dates.map((item, i) => {
-      return (
-        <MenuItem value={item} key={i}>
-          { item }
-        </MenuItem>
-      )
-    })
-    return (
-      <Card>
-        <CardHeader style={{ paddingBottom: 0 }} title="Filter By" titleTypographyProps={{ variant: 'body1' }}/>
-        <CardContent style={{ paddingTop: 0, paddingLeft: '.5em' }}>
-          <FormControl className={ classes.formControl }>
-            <InputLabel>Line</InputLabel>
-            <Select
-              className={ classes.selectEmpty }
-              value={ line }
-              onChange={ handleLineChange }
-              name="Line"
-            >
-              <MenuItem value={"All"}>
-                <div style={{display: "flex", alignItems: "center"}}>
-                  <ListItemAvatar>
-                    <Avatar className={ classes.avatar }>
-                      <div style={{ backgroundColor: '#dddddd', }} className={ classes.lineDot } />
-                    </Avatar>
-                  </ListItemAvatar>
-                  All Lines
-                </div>
-              </MenuItem>
-              { lineSelectors }
-            </Select>
-          </FormControl>
-          <FormControl className={ classes.formControl }>
-            <InputLabel>Cutoff</InputLabel>
-            <Select
-              className={ classes.selectEmpty }
-              value={ arrivalWindow }
-              onChange={ handleArrivalWindow }
-              name="arrivalWindow"
-            >
-              { windows }
-            </Select>
-          </FormControl>
-          <FormControl className={ classes.formControl }>
-            <InputLabel>Date</InputLabel>
-            <Select
-              className={ classes.selectEmpty }
-              value={ date }
-              onChange={ handleDate }
-              name="Date"
-            >
-              { dateSelectors }
-            </Select>
-          </FormControl>
-        </CardContent>
-      </Card>
-    )
-  }
-}
+      </div>
+    </MenuItem>
+  ));
+  const dateSelectors = dates.map((item, i) => (
+    <MenuItem value={item} key={i}>
+      { item }
+    </MenuItem>
+  ));
+  return (
+    <Card>
+      <CardHeader style={{ paddingBottom: 0 }} title="Filter By" titleTypographyProps={{ variant: 'body1' }} />
+      <CardContent style={{ paddingTop: 0, paddingLeft: '.5em' }}>
+        <FormControl className={classes.formControl}>
+          <InputLabel>Line</InputLabel>
+          <Select
+            className={classes.selectEmpty}
+            value={line}
+            onChange={handleLineChange}
+            name="Line"
+          >
+            <MenuItem value="All">
+              <div style={{ display: 'flex', alignItems: 'center' }}>
+                <ListItemAvatar>
+                  <Avatar className={classes.avatar}>
+                    <div style={{ backgroundColor: '#dddddd' }} className={classes.lineDot} />
+                  </Avatar>
+                </ListItemAvatar>
+                All Lines
+              </div>
+            </MenuItem>
+            { lineSelectors }
+          </Select>
+        </FormControl>
+        <FormControl className={classes.formControl}>
+          <InputLabel>Cutoff</InputLabel>
+          <Select
+            className={classes.selectEmpty}
+            value={arrivalWindow}
+            onChange={handleArrivalWindow}
+            name="arrivalWindow"
+          >
+            { windows }
+          </Select>
+        </FormControl>
+        <FormControl className={classes.formControl}>
+          <InputLabel>Date</InputLabel>
+          <Select
+            className={classes.selectEmpty}
+            value={date}
+            onChange={handleDate}
+            name="Date"
+          >
+            { dateSelectors }
+          </Select>
+        </FormControl>
+      </CardContent>
+    </Card>
+  );
+};
 
 export default withStyles(styles)(FilterPanel);

--- a/components/HistoryMenu.jsx
+++ b/components/HistoryMenu.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
-import { AppBar, Button, Tab, Tabs, Grid, Typography, Card, Select, MenuItem, ListItemAvatar, Avatar } from '@material-ui/core';
+import {
+  Typography, Card, Select, MenuItem, ListItemAvatar, Avatar,
+} from '@material-ui/core';
 import { withStyles } from '@material-ui/core/styles';
-import { lineLinks, linesByName } from '../helpers/LineInfo.js';
+import { lineLinks } from '~/helpers/LineInfo';
 
 const styles = theme => ({
   card: {
@@ -11,107 +13,123 @@ const styles = theme => ({
   },
   selectEmpty: {
     marginTop: theme.spacing.unit * 2,
-    marginLeft: ".5em",
+    marginLeft: '.5em',
     marginBottom: '-.25em',
   },
   header: {
-    marginLeft: "1.6em",
+    marginLeft: '1.6em',
     fontSize: 16,
   },
   avatar: {
     width: 16,
     height: 16,
-    marginRight: ".5em"
+    marginRight: '.5em',
   },
   headerContainer: {
-    paddingBottom: "1em",
-    display: "flex",
-    alignItems: "flex-end",
-    flexWrap: "wrap"
-  }
+    paddingBottom: '1em',
+    display: 'flex',
+    alignItems: 'flex-end',
+    flexWrap: 'wrap',
+  },
 });
 
-class HistoryMenu extends React.Component {
-	constructor(props) {
-		super(props);
-	}
-	render() {
-		const { classes, line, handleLineChange, dataFormat, xAxis, handleXAxisChange, yAxis, handleYAxisChange  } = this.props;
-		return (
-			<Card className={classes.card}>
-	          <div className={classes.headerContainer}>
-	          <div>
-	          <Typography className={classes.header} inline={true}>View Data for
-	          </Typography>
-	          <Select
-	            value={line}
-	            onChange={handleLineChange}
-	            name="line"
-	            className={classes.selectEmpty}
-	          >
-	            <MenuItem value={"All Lines"}>
-	              <div style={{display: "flex", alignItems: "center"}}>
-	              <ListItemAvatar>
-	                <Avatar className={ classes.avatar }>
-	                  <div
-	                    style={{
-	                      backgroundColor: '#dddddd',
-	                      width: '100%',
-	                      padding: 0,
-	                      height: '100%',
-	                      margin: 0,
-	                      borderRadius: '50%',
-	                    }}
-	                  />
-	                </Avatar>
-	              </ListItemAvatar>
-	              All Lines
-	              </div>
-	            </MenuItem>
-	            {lineLinks(classes)}
-	          </Select>
-	          </div>
-	          { dataFormat === "chart" ?
-	          <React.Fragment>
-	          <div>
-	          <Typography className={classes.header} inline={true}>X-Axis:
-	          </Typography>
-	          <Select
-	            value={xAxis}
-	            onChange={handleXAxisChange}
-	            name="xAxis"
-	            className={classes.selectEmpty}
-	          >
-	            <MenuItem value={"Last 30 Days"}>Last 30 Days
-	            </MenuItem>
-	            <MenuItem value={"Weekday Average"}>Weekday Average
-	            </MenuItem>
-	          </Select>
-	          </div>
-	          <div>
-	          <Typography className={classes.header} inline={true}>Y-Axis:
-	          </Typography>
-	          <Select
-	            value={yAxis}
-	            onChange={handleYAxisChange}
-	            name="yAxis"
-	            className={classes.selectEmpty}
-	          >
-	            <MenuItem value={"Average Wait Time"}>Average Wait Time
-	            </MenuItem>
-	            <MenuItem value={"% Within 1 Minute"}>% Within 1 Minute
-	            </MenuItem>
-	            <MenuItem value={"% Within 5 Minutes"}>% Within 5 Minutes
-	            </MenuItem>
-	          </Select>
-	          </div>
-	          </React.Fragment>
-	          : ""
-	          }
-	        </div>
-	        </Card>
-		)
-	}
-}
+const HistoryMenu = (props) => {
+  const {
+    classes, line, handleLineChange, dataFormat, xAxis, handleXAxisChange, yAxis, handleYAxisChange,
+  } = props;
+  return (
+    <Card className={classes.card}>
+      <div className={classes.headerContainer}>
+        <div>
+          <Typography className={classes.header} inline>
+View Data for
+
+            {' '}
+          </Typography>
+          <Select
+            value={line}
+            onChange={handleLineChange}
+            name="line"
+            className={classes.selectEmpty}
+          >
+            <MenuItem value="All Lines">
+              <div style={{ display: 'flex', alignItems: 'center' }}>
+                <ListItemAvatar>
+                  <Avatar className={classes.avatar}>
+                    <div
+                      style={{
+                        backgroundColor: '#dddddd',
+                        width: '100%',
+                        padding: 0,
+                        height: '100%',
+                        margin: 0,
+                        borderRadius: '50%',
+                      }}
+                    />
+                  </Avatar>
+                </ListItemAvatar>
+              All Lines
+
+                {' '}
+              </div>
+            </MenuItem>
+            {lineLinks(classes)}
+          </Select>
+        </div>
+        { dataFormat === 'chart' ? (
+          <React.Fragment>
+            <div>
+              <Typography className={classes.header} inline>
+                X-Axis:
+                {' '}
+              </Typography>
+              <Select
+                value={xAxis}
+                onChange={handleXAxisChange}
+                name="xAxis"
+                className={classes.selectEmpty}
+              >
+                <MenuItem value="Last 30 Days">
+                  Last 30 Days
+                  {' '}
+                </MenuItem>
+                <MenuItem value="Weekday Average">
+                  Weekday Average
+                  {' '}
+                </MenuItem>
+              </Select>
+            </div>
+            <div>
+              <Typography className={classes.header} inline>
+                Y-Axis:
+                {' '}
+              </Typography>
+              <Select
+                value={yAxis}
+                onChange={handleYAxisChange}
+                name="yAxis"
+                className={classes.selectEmpty}
+              >
+                <MenuItem value="Average Wait Time">
+                  Average Wait Time
+                  {' '}
+                </MenuItem>
+                <MenuItem value="% Within 1 Minute">
+                  % Within 1 Minute
+                  {' '}
+                </MenuItem>
+                <MenuItem value="% Within 5 Minutes">
+                  % Within 5 Minutes
+                  {' '}
+                </MenuItem>
+              </Select>
+            </div>
+          </React.Fragment>
+        ) : ''
+          }
+      </div>
+    </Card>
+  );
+};
 
 export default withStyles(styles)(HistoryMenu);

--- a/components/HistoryTable.jsx
+++ b/components/HistoryTable.jsx
@@ -1,6 +1,4 @@
-import React from 'react';
-import { Typography, Card } from '@material-ui/core';
-import axios from 'axios';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import Table from '@material-ui/core/Table';
@@ -10,14 +8,8 @@ import TableCell from '@material-ui/core/TableCell';
 import TableFooter from '@material-ui/core/TableFooter';
 import TablePagination from '@material-ui/core/TablePagination';
 import TableRow from '@material-ui/core/TableRow';
-import Paper from '@material-ui/core/Paper';
-import IconButton from '@material-ui/core/IconButton';
-import FirstPageIcon from '@material-ui/icons/FirstPage';
-import KeyboardArrowLeft from '@material-ui/icons/KeyboardArrowLeft';
-import KeyboardArrowRight from '@material-ui/icons/KeyboardArrowRight';
-import LastPageIcon from '@material-ui/icons/LastPage';
-import { dateToString } from "../helpers/formatHistory"
-
+import { dateToString } from '~/helpers/formatHistory';
+import TablePaginationActions from "~/components/TablePaginationActions";
 
 const styles = theme => ({
   root: {
@@ -37,12 +29,12 @@ const styles = theme => ({
   },
 });
 
-class HistoryTable extends React.Component {
+class HistoryTable extends Component {
   constructor(props) {
     super(props);
     this.state = {
       page: 0,
-      rowsPerPage: 10
+      rowsPerPage: 10,
     };
   }
 
@@ -50,57 +42,57 @@ class HistoryTable extends React.Component {
     this.setState({ page });
   };
 
-  handleChangeRowsPerPage = event => {
+  handleChangeRowsPerPage = (event) => {
     this.setState({ page: 0, rowsPerPage: Number(event.target.value) });
   };
 
   render() {
     const { classes, rows } = this.props;
     const { rowsPerPage, page } = this.state;
-    const emptyRows = rowsPerPage - Math.min(rowsPerPage, rows.length - page * rowsPerPage);
+    // const emptyRows = rowsPerPage - Math.min(rowsPerPage, rows.length - page * rowsPerPage);
     return (
-          <div className={classes.tableWrapper}>
-            <Table className={classes.table}>
-              <TableHead>
-                <TableRow>
-                  <TableCell>Date</TableCell>
-                  <TableCell align="right">Within 1 min.</TableCell>
-                  <TableCell align="right">Within 5 min.</TableCell>
-                  <TableCell align="right">Avg. wait time</TableCell>
+      <div className={classes.tableWrapper}>
+        <Table className={classes.table}>
+          <TableHead>
+            <TableRow>
+              <TableCell>Date</TableCell>
+              <TableCell align="right">Within 1 min.</TableCell>
+              <TableCell align="right">Within 5 min.</TableCell>
+              <TableCell align="right">Avg. wait time</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {rows.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+              .map(row => (
+                <TableRow key={row.id}>
+                  <TableCell component="th" scope="row">
+                    {dateToString(row.id)}
+                  </TableCell>
+                  <TableCell align="right">{`${Math.round(1000 * row.ontime['1_min'] / row.total_arrivals_analyzed) / 10}%`}</TableCell>
+                  <TableCell align="right">{`${Math.round(1000 * row.ontime['5_min'] / row.total_arrivals_analyzed) / 10}%`}</TableCell>
+                  <TableCell align="right">{`${Math.round(row.mean_time_between / 60)} min.`}</TableCell>
                 </TableRow>
-              </TableHead>
-              <TableBody>
-                {rows.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
-                     .map((row,i) => (
-                        <TableRow key={row.id}>
-                          <TableCell component="th" scope="row">
-                            {dateToString(row.id)}
-                          </TableCell>
-                          <TableCell align="right">{Math.round(1000 * row.ontime["1_min"] / row.total_arrivals_analyzed) / 10 + "%"}</TableCell>
-                          <TableCell align="right">{Math.round(1000 * row.ontime["5_min"] / row.total_arrivals_analyzed) / 10 + "%"}</TableCell>
-                          <TableCell align="right">{Math.round(row.mean_time_between/60) + " min."}</TableCell>
-                        </TableRow>
-                ))}
-              </TableBody>           
-              <TableFooter>
-                <TableRow>
-                  <TablePagination
-                    rowsPerPageOptions={[10, 25, 50]}
-                    colSpan={3}
-                    count={rows.length}
-                    rowsPerPage={rowsPerPage}
-                    page={page}
-                    SelectProps={{
-                      native: true,
-                    }}
-                    onChangePage={this.handleChangePage}
-                    onChangeRowsPerPage={this.handleChangeRowsPerPage}
-                    ActionsComponent={TablePaginationActionsWrapped}
-                  />
-                </TableRow>
-              </TableFooter>
-            </Table>
-          </div>
+              ))}
+          </TableBody>
+          <TableFooter>
+            <TableRow>
+              <TablePagination
+                rowsPerPageOptions={[10, 25, 50]}
+                colSpan={3}
+                count={rows.length}
+                rowsPerPage={rowsPerPage}
+                page={page}
+                SelectProps={{
+                  native: true,
+                }}
+                onChangePage={this.handleChangePage}
+                onChangeRowsPerPage={this.handleChangeRowsPerPage}
+                ActionsComponent={TablePaginationActions}
+              />
+            </TableRow>
+          </TableFooter>
+        </Table>
+      </div>
     );
   }
 }
@@ -108,84 +100,5 @@ class HistoryTable extends React.Component {
 HistoryTable.propTypes = {
   classes: PropTypes.object.isRequired,
 };
-
-
-const actionsStyles = theme => ({
-  root: {
-    flexShrink: 0,
-    color: theme.palette.text.secondary,
-    marginLeft: theme.spacing.unit * 2.5,
-  },
-});
-
-class TablePaginationActions extends React.Component {
-  handleFirstPageButtonClick = event => {
-    this.props.onChangePage(event, 0);
-  };
-
-  handleBackButtonClick = event => {
-    this.props.onChangePage(event, this.props.page - 1);
-  };
-
-  handleNextButtonClick = event => {
-    this.props.onChangePage(event, this.props.page + 1);
-  };
-
-  handleLastPageButtonClick = event => {
-    this.props.onChangePage(
-      event,
-      Math.max(0, Math.ceil(this.props.count / this.props.rowsPerPage) - 1),
-    );
-  };
-
-  render() {
-    const { classes, count, page, rowsPerPage, theme } = this.props;
-    return (
-      <div className={classes.root}>
-        <IconButton
-          onClick={this.handleFirstPageButtonClick}
-          disabled={page === 0}
-          aria-label="First Page"
-        >
-          {theme.direction === 'rtl' ? <LastPageIcon /> : <FirstPageIcon />}
-        </IconButton>
-        <IconButton
-          onClick={this.handleBackButtonClick}
-          disabled={page === 0}
-          aria-label="Previous Page"
-        >
-          {theme.direction === 'rtl' ? <KeyboardArrowRight /> : <KeyboardArrowLeft />}
-        </IconButton>
-        <IconButton
-          onClick={this.handleNextButtonClick}
-          disabled={page >= Math.ceil(count / rowsPerPage) - 1}
-          aria-label="Next Page"
-        >
-          {theme.direction === 'rtl' ? <KeyboardArrowLeft /> : <KeyboardArrowRight />}
-        </IconButton>
-        <IconButton
-          onClick={this.handleLastPageButtonClick}
-          disabled={page >= Math.ceil(count / rowsPerPage) - 1}
-          aria-label="Last Page"
-        >
-          {theme.direction === 'rtl' ? <FirstPageIcon /> : <LastPageIcon />}
-        </IconButton>
-      </div>
-    );
-  }
-}
-
-TablePaginationActions.propTypes = {
-  classes: PropTypes.object.isRequired,
-  count: PropTypes.number.isRequired,
-  onChangePage: PropTypes.func.isRequired,
-  page: PropTypes.number.isRequired,
-  theme: PropTypes.object.isRequired,
-};
-
-const TablePaginationActionsWrapped = withStyles(actionsStyles, { withTheme: true })(
-  TablePaginationActions,
-);
-
 
 export default withStyles(styles)(HistoryTable);

--- a/components/HistoryTable.jsx
+++ b/components/HistoryTable.jsx
@@ -9,7 +9,7 @@ import TableFooter from '@material-ui/core/TableFooter';
 import TablePagination from '@material-ui/core/TablePagination';
 import TableRow from '@material-ui/core/TableRow';
 import { dateToString } from '~/helpers/formatHistory';
-import TablePaginationActions from "~/components/TablePaginationActions";
+import TablePaginationActions from '~/components/TablePaginationActions';
 
 const styles = theme => ({
   root: {

--- a/components/Layout.jsx
+++ b/components/Layout.jsx
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import Head from 'next/head';
 import classNames from 'classnames';
 import {
@@ -10,24 +10,20 @@ import {
   ListItemText,
   ListItemAvatar,
   Avatar,
-  Typography,
   Drawer,
 } from '@material-ui/core';
 import DirectionsTransitIcon from '@material-ui/icons/DirectionsTransit';
 import LocationCityIcon from '@material-ui/icons/LocationCity';
 import InfoIcon from '@material-ui/icons/Info';
-import PlaceIcon from '@material-ui/icons/Place';
-import MenuIcon from '@material-ui/icons/Menu';
 import HistoryIcon from '@material-ui/icons/History';
 import ExpandLess from '@material-ui/icons/ExpandLess';
 import ExpandMore from '@material-ui/icons/ExpandMore';
 import { withStyles } from '@material-ui/core/styles';
 import withWidth from '@material-ui/core/withWidth';
 import flowRight from 'lodash/flowRight';
-import SvgIcon from '@material-ui/core/SvgIcon';
 import Link from 'next/link';
 import Nav from './Nav';
-import { lines } from '../helpers/LineInfo.js';
+import { lines } from '~/helpers/LineInfo';
 
 const drawerWidth = 300;
 
@@ -71,8 +67,8 @@ const styles = theme => ({
   },
   avatar: {
     width: 25,
-    height: 25
-  }
+    height: 25,
+  },
 });
 
 class Layout extends Component {
@@ -90,16 +86,23 @@ class Layout extends Component {
   };
 
   render() {
-    const { classes } = this.props;
-    const selectedTab = this.state.selectedTab;
+    const {
+      classes,
+      pageTitle,
+      children,
+      toolbarTitle,
+      toolbarChildren,
+      style
+    } = this.props;
+    const { drawerOpen, subMenuOpen } = this.state;
 
     const links = (
       <List>
         {lines.map(line => (
-          <Link prefetch href={{ pathname: '/line', query: {id: line.id} }} as={`/line/${line.id}`} key={line.id.toString()}>
-            <ListItem button onClick={ this.handleDrawer }>
+          <Link prefetch href={{ pathname: '/line', query: { id: line.id } }} as={`/line/${line.id}`} key={line.id.toString()}>
+            <ListItem button onClick={this.handleDrawer}>
               <ListItemAvatar>
-                <Avatar className={ classes.avatar }>
+                <Avatar className={classes.avatar}>
                   <div
                     style={{
                       backgroundColor: line.color,
@@ -123,23 +126,26 @@ class Layout extends Component {
     return (
       <div style={{ minHeight: '100%' }}>
         <Head>
-          <title>RailStats LA | {this.props.pageTitle}</title>
+          <title>
+RailStats LA |
+            {pageTitle}
+          </title>
         </Head>
         {' '}
-        <Drawer variant="persistent" classes={{ paper: classes.drawer }} open={this.state.drawerOpen}>
+        <Drawer variant="persistent" classes={{ paper: classes.drawer }} open={drawerOpen}>
           <List>
-            <Link href='/'>
-              <ListItem onClick={ this.handleDrawer } style={{ padding: '5px 8px 5px 16px', cursor: 'pointer' }}>
+            <Link href="/">
+              <ListItem onClick={this.handleDrawer} style={{ padding: '5px 8px 5px 16px', cursor: 'pointer' }}>
                 <ListItemIcon>
                   <img src="/static/images/logo_network.svg" className={classes.logo} alt="Logo" />
                 </ListItemIcon>
-                <ListItemText primary="RailStats LA" classes={{ primary: classes.logoText }}/>
+                <ListItemText primary="RailStats LA" classes={{ primary: classes.logoText }} />
               </ListItem>
             </Link>
             <Divider />
             {' '}
-            <Link prefetch href='/'>
-              <ListItem button onClick={ this.handleDrawer }>
+            <Link prefetch href="/">
+              <ListItem button onClick={this.handleDrawer}>
                 <LocationCityIcon className={classes.icon} style={{ marginLeft: 0 }} />
                 <ListItemText inset primary="Network" />
               </ListItem>
@@ -147,30 +153,41 @@ class Layout extends Component {
             <ListItem button onClick={this.handleSubMenu}>
               <DirectionsTransitIcon className={classes.icon} style={{ marginLeft: 0 }} />
               <ListItemText inset primary="Lines" />
-              {this.state.subMenuOpen ? <ExpandLess /> : <ExpandMore />}
+              {subMenuOpen ? <ExpandLess /> : <ExpandMore />}
             </ListItem>
-            <Collapse in={this.state.subMenuOpen} timeout="auto" unmountOnExit>
+            <Collapse in={subMenuOpen} timeout="auto" unmountOnExit>
               {links}
             </Collapse>
-            <Link prefetch href='/about'>
-              <ListItem button onClick={ this.handleDrawer }>
+            <Link prefetch href="/about">
+              <ListItem button onClick={this.handleDrawer}>
                 <InfoIcon className={classes.icon} style={{ marginLeft: 0 }} />
                 <ListItemText inset primary="About" />
               </ListItem>
             </Link>
-            <Link prefetch href='/history'>
-              <ListItem button onClick={ this.handleDrawer }>
+            <Link prefetch href="/history">
+              <ListItem button onClick={this.handleDrawer}>
                 <HistoryIcon className={classes.icon} style={{ marginLeft: 0 }} />
                 <ListItemText inset primary="History" />
               </ListItem>
             </Link>
           </List>
         </Drawer>
-        <Nav navClasses={classNames(classes.content, { [classes.contentShift]: this.state.drawerOpen, })} pageTitle={this.props.toolbarTitle} handleMenuButton={this.handleDrawer}>
-          {this.props.toolbarChildren}
+        <Nav
+          navClasses={classNames(classes.content, {
+            [classes.contentShift]: drawerOpen
+          })}
+          pageTitle={toolbarTitle}
+          handleMenuButton={this.handleDrawer}
+        >
+          {toolbarChildren}
         </Nav>
-        <div className={classNames(classes.main, classes.content, { [classes.contentShift]: this.state.drawerOpen, })} style={{ ...this.props.style }}>
-          {this.props.children}
+        <div
+          className={classNames(classes.main, classes.content, {
+            [classes.contentShift]: drawerOpen
+          })}
+          style={{ ...style }}
+        >
+          {children}
         </div>
       </div>
     );

--- a/components/Layout.jsx
+++ b/components/Layout.jsx
@@ -92,14 +92,19 @@ class Layout extends Component {
       children,
       toolbarTitle,
       toolbarChildren,
-      style
+      style,
     } = this.props;
     const { drawerOpen, subMenuOpen } = this.state;
 
     const links = (
       <List>
         {lines.map(line => (
-          <Link prefetch href={{ pathname: '/line', query: { id: line.id } }} as={`/line/${line.id}`} key={line.id.toString()}>
+          <Link
+            prefetch
+            href={{ pathname: '/line', query: { id: line.id } }}
+            as={`/line/${line.id}`}
+            key={line.id.toString()}
+          >
             <ListItem button onClick={this.handleDrawer}>
               <ListItemAvatar>
                 <Avatar className={classes.avatar}>
@@ -127,7 +132,7 @@ class Layout extends Component {
       <div style={{ minHeight: '100%' }}>
         <Head>
           <title>
-RailStats LA |
+            RailStats LA |
             {pageTitle}
           </title>
         </Head>
@@ -174,7 +179,7 @@ RailStats LA |
         </Drawer>
         <Nav
           navClasses={classNames(classes.content, {
-            [classes.contentShift]: drawerOpen
+            [classes.contentShift]: drawerOpen,
           })}
           pageTitle={toolbarTitle}
           handleMenuButton={this.handleDrawer}
@@ -183,7 +188,7 @@ RailStats LA |
         </Nav>
         <div
           className={classNames(classes.main, classes.content, {
-            [classes.contentShift]: drawerOpen
+            [classes.contentShift]: drawerOpen,
           })}
           style={{ ...style }}
         >

--- a/components/LineComparison.jsx
+++ b/components/LineComparison.jsx
@@ -1,84 +1,80 @@
-import React from "react";
+import React from 'react';
 import {
   Card,
   Typography,
-  MenuItem,
   Select,
-  Avatar,
-  ListItemAvatar
-} from "@material-ui/core";
-import { Slider } from "@material-ui/lab";
-import { withStyles } from "@material-ui/core/styles";
-import HistoryChart from "~/components/charts/HistoryChart";
+} from '@material-ui/core';
+import { Slider } from '@material-ui/lab';
+import { withStyles } from '@material-ui/core/styles';
+import HistoryChart from '~/components/charts/HistoryChart';
 import {
   dateToString,
   deriveLine,
   deriveXAxis,
   deriveYAxis,
-  prepareTableData
-} from "../helpers/formatHistory";
-import { lineLinks, linesByName } from "../helpers/LineInfo.js";
+} from '../helpers/formatHistory';
+import { lineLinks, linesByName } from '~/helpers/LineInfo';
 
 const styles = theme => ({
   card: {
     maxWidth: 1200,
-    margin: "auto",
-    marginTop: 20
+    margin: 'auto',
+    marginTop: 20,
   },
   chartContainer: {
-    margin: "auto",
-    width: "100%",
-    marginTop: "1em",
-    marginBottom: "1em",
-    paddingTop: "2em",
-    paddingBottom: "2em",
-    paddingLeft: "5%",
-    paddingRight: "5%",
-    backgroundColor: "#f8f8f8"
+    margin: 'auto',
+    width: '100%',
+    marginTop: '1em',
+    marginBottom: '1em',
+    paddingTop: '2em',
+    paddingBottom: '2em',
+    paddingLeft: '5%',
+    paddingRight: '5%',
+    backgroundColor: '#f8f8f8',
   },
   headerContainer: {
-    marginTop: "1em",
-    paddingBottom: "1em",
-    display: "flex",
-    alignItems: "flex-end",
-    justifyContent: "space-around",
-    flexWrap: "wrap"
+    marginTop: '1em',
+    paddingBottom: '1em',
+    display: 'flex',
+    alignItems: 'flex-end',
+    justifyContent: 'space-around',
+    flexWrap: 'wrap',
   },
   header: {
     fontSize: 36,
-    marginBottom: "-.25em",
-    textAlign: "center"
+    marginBottom: '-.25em',
+    textAlign: 'center',
   },
   compareText: {
-    fontSize: 16
+    fontSize: 16,
   },
   selectEmpty: {
     marginTop: theme.spacing.unit * 2,
-    marginLeft: ".5em",
-    marginBottom: "-.25em"
+    marginLeft: '.5em',
+    marginBottom: '-.25em',
   },
   avatar: {
     width: 16,
     height: 16,
-    marginRight: ".5em"
+    marginRight: '.5em',
   },
   slider: {
-    padding: "22px 0px"
+    padding: '22px 0px',
   },
   sliderContainer: {
-    width: "30%",
-    marginLeft: "auto",
-    marginRight: "auto",
-    paddingBottom: "1em",
-    paddingTop: "1em",
-    textAlign: "center"
+    width: '30%',
+    marginLeft: 'auto',
+    marginRight: 'auto',
+    paddingBottom: '1em',
+    paddingTop: '1em',
+    textAlign: 'center',
   },
   trackBefore: {
-    opacity: ".2"
+    opacity: '.2',
   },
   trackAfter: {
-    opacity: "1"
-  }
+    opacity: '1',
+  },
 });
 
 class LineComparison extends React.Component {
@@ -87,18 +83,18 @@ class LineComparison extends React.Component {
     this.state = {
       graphData: [],
       allLineGraph: [],
-      line: "Blue",
-      xAxis: "All Daily Data",
+      line: 'Blue',
+      xAxis: 'All Daily Data',
       xTickFormat: [],
-      yAxis: "% Within 5 Minutes",
+      yAxis: '% Within 5 Minutes',
       yTickFormat: {
-        formatter: function() {
+        formatter() {
           return `${this.value}%`;
-        }
+        },
       },
-      color: "#2461aa",
+      color: '#2461aa',
       value: 0,
-      sliderLabel: "All Time"
+      sliderLabel: 'All Time',
     };
   }
 
@@ -108,54 +104,57 @@ class LineComparison extends React.Component {
         graphData: deriveYAxis(
           deriveXAxis(
             deriveLine(props.formattedData, state.line, props.allLineData),
-            state.xAxis
+            state.xAxis,
           ),
-          state.yAxis
+          state.yAxis,
         ),
         allLineGraph: deriveYAxis(
           deriveXAxis(
-            deriveLine(props.formattedData, "All Lines", props.allLineData),
-            state.xAxis
+            deriveLine(props.formattedData, 'All Lines', props.allLineData),
+            state.xAxis,
           ),
-          state.yAxis
-        )
+          state.yAxis,
+        ),
       };
     }
     return null;
   }
 
-  handleSlide = (event, value) => {
-    this.setState({ value });
-    this.setLabel(value);
-    this.formatGraphData(value);
-  };
+  componentDidMount() {
+    this.setState(prevState => ({
+      xTickFormat: prevState.graphData.map((item, i) => (
+        dateToString(prevState.graphData.length - 1 - i)
+      )),
+    }));
+  }
 
-  setLabel = value => {
+  setLabel = (value) => {
     switch (value) {
       case 0:
-        this.setState({ sliderLabel: "All Time" });
+        this.setState({ sliderLabel: 'All Time' });
         break;
       case 1:
-        this.setState({ sliderLabel: "90 Days" });
+        this.setState({ sliderLabel: '90 Days' });
         break;
       case 2:
-        this.setState({ sliderLabel: "30 Days" });
+        this.setState({ sliderLabel: '30 Days' });
         break;
       default:
-        this.setState({ sliderLabel: "7 Days" });
+        this.setState({ sliderLabel: '7 Days' });
         break;
     }
   };
 
-  formatGraphData = value => {
+  formatGraphData = (value) => {
     const { formattedData, allLineData } = this.props;
+    const { xAxis, yAxis, line } = this.state;
     let cutOff;
     switch (value) {
       case 0:
         cutOff = formattedData.length;
         break;
       case 1:
-        if (90 < formattedData.length) {
+        if (formattedData.length > 90) {
           cutOff = 90;
         }
         break;
@@ -172,55 +171,55 @@ class LineComparison extends React.Component {
           deriveLine(
             formattedData.slice(
               formattedData.length - cutOff,
-              formattedData.length
+              formattedData.length,
             ),
-            this.state.line,
-            allLineData.slice(allLineData.length - cutOff, allLineData.length)
+            line,
+            allLineData.slice(allLineData.length - cutOff, allLineData.length),
           ),
-          this.state.xAxis
+          xAxis,
         ),
-        this.state.yAxis
+        yAxis,
       ),
       allLineGraph: deriveYAxis(
         deriveXAxis(
           deriveLine(
             formattedData.slice(
               formattedData.length - cutOff,
-              formattedData.length
+              formattedData.length,
             ),
-            "All Lines",
-            allLineData.slice(allLineData.length - cutOff, allLineData.length)
+            'All Lines',
+            allLineData.slice(allLineData.length - cutOff, allLineData.length),
           ),
-          this.state.xAxis
+          xAxis,
         ),
-        this.state.yAxis
-      )
+        yAxis,
+      ),
     });
   };
 
-  componentDidMount() {
-    this.setState(prevState => ({
-      xTickFormat: prevState.graphData.map((item, i) => {
-        return dateToString(prevState.graphData.length - 1 - i);
-      })
-    }));
-  }
+  handleSlide = (event, value) => {
+    this.setState({ value });
+    this.setLabel(value);
+    this.formatGraphData(value);
+  };
 
-  handleLineChange = event => {
+  handleLineChange = (event) => {
+    const { formattedData, allLineData } = this.props;
+    const { xAxis, yAxis } = this.state;
     this.setState({
       line: event.target.value,
-      color: linesByName[event.target.value]["color"],
+      color: linesByName[event.target.value].color,
       graphData: deriveYAxis(
         deriveXAxis(
           deriveLine(
-            this.props.formattedData,
+            formattedData,
             event.target.value,
-            this.props.allLineData
+            allLineData,
           ),
-          this.state.xAxis
+          xAxis,
         ),
-        this.state.yAxis
-      )
+        yAxis,
+      ),
     });
   };
 
@@ -235,7 +234,7 @@ class LineComparison extends React.Component {
       yTickFormat,
       yAxis,
       line,
-      sliderLabel
+      sliderLabel,
     } = this.state;
 
     return (
@@ -245,7 +244,7 @@ class LineComparison extends React.Component {
             All Line Performance Chart
           </Typography>
           <div>
-            <Typography className={classes.compareText} inline={true}>
+            <Typography className={classes.compareText} inline>
               Compare:
             </Typography>
             <Select
@@ -260,27 +259,30 @@ class LineComparison extends React.Component {
         </div>
         <div className={classes.chartContainer}>
           <HistoryChart
-            chartFormat={"line"}
-            bgColor={"#f8f8f8"}
+            chartFormat="line"
+            bgColor="#f8f8f8"
             graphData={graphData}
             color={color}
             xTickFormat={xTickFormat}
             yTickFormat={yTickFormat}
             yAxis={yAxis}
             secondSeries={{
-              name: "",
-              color: "#c8c8c8",
-              data: allLineGraph
+              name: '',
+              color: '#c8c8c8',
+              data: allLineGraph,
             }}
           />
         </div>
         <div className={classes.sliderContainer}>
-          <Typography id="slider-icon">View data for {sliderLabel}</Typography>
+          <Typography id="slider-icon">
+View data for
+            {sliderLabel}
+          </Typography>
           <Slider
             classes={{
               container: classes.slider,
               trackBefore: classes.trackBefore,
-              trackAfter: classes.trackAfter
+              trackAfter: classes.trackAfter,
             }}
             value={value}
             min={0}

--- a/components/LineSelector.jsx
+++ b/components/LineSelector.jsx
@@ -2,9 +2,8 @@ import React, { Component, Fragment } from 'react';
 import {
   Button,
   Card,
-  CardHeader,
   CardContent,
-  Typography
+  Typography,
 } from '@material-ui/core';
 import { withStyles } from '@material-ui/core/styles';
 import { lines } from '~/helpers/LineInfo.js';
@@ -23,60 +22,54 @@ const styles = theme => ({
     color: theme.palette.text.secondary,
   },
   title: {
-    fontWeight: 200
-  }
+    fontWeight: 200,
+  },
 });
 
 
-class LineSelector extends Component {
-  constructor(props) {
-    super(props)
-  }
-
-  render() {
-    const { classes } = this.props;
-    const lineButton = (line) => {
-      return (
-        <Link prefetch href={{ pathname: `/line`, query: {id: line.id} }} as={`/line/${line.id}`}>
-          <Button variant="outlined" className={classes.button}>
-            <div className={classes.buttonWrapper} style={{ position: 'relative' }}>
-              <Circle color={line.color} />
-              <div>
-                <Typography component="h4">{line.name} Line</Typography>
-              </div>
-            </div>
-          </Button>
-        </Link>
-      )
-    };
-
-    const lineButtons = () => {
-      const allLines = lines.map((line) => {
-        return (
-            <div key={line.name}>
-              { lineButton(line) }
-            </div>
-      )});
-      return (
-        <Card>
-          <CardContent>
-            <Typography variant="body2" className={classes.title}>
-              Select below to filter by line:
+const LineSelector = (props) => {
+  const { classes } = props;
+  const lineButton = line => (
+    <Link prefetch href={{ pathname: '/line', query: { id: line.id } }} as={`/line/${line.id}`}>
+      <Button variant="outlined" className={classes.button}>
+        <div className={classes.buttonWrapper} style={{ position: 'relative' }}>
+          <Circle color={line.color} />
+          <div>
+            <Typography component="h4">
+              {line.name}
+              {' '}
+Line
             </Typography>
-            <div style={{ display: 'flex', justifyContent: 'center', flexWrap: 'wrap' }}>
-              { allLines }
-            </div>
-          </CardContent>
-        </Card>
-      )
-    };
-    return (
-      <Fragment>
-        { lineButtons() }
-      </Fragment>
-    )
-  }
-}
+          </div>
+        </div>
+      </Button>
+    </Link>
+  );
 
+  const lineButtons = () => {
+    const allLines = lines.map(line => (
+      <div key={line.name}>
+        { lineButton(line) }
+      </div>
+    ));
+    return (
+      <Card>
+        <CardContent>
+          <Typography variant="body2" className={classes.title}>
+            Select below to filter by line:
+          </Typography>
+          <div style={{ display: 'flex', justifyContent: 'center', flexWrap: 'wrap' }}>
+            { allLines }
+          </div>
+        </CardContent>
+      </Card>
+    );
+  };
+  return (
+    <Fragment>
+      { lineButtons() }
+    </Fragment>
+  );
+};
 
 export default withStyles(styles)(LineSelector);

--- a/components/LineSelector.jsx
+++ b/components/LineSelector.jsx
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react';
+import React, { Fragment } from 'react';
 import {
   Button,
   Card,
@@ -6,7 +6,7 @@ import {
   Typography,
 } from '@material-ui/core';
 import { withStyles } from '@material-ui/core/styles';
-import { lines } from '~/helpers/LineInfo.js';
+import { lines } from '~/helpers/LineInfo';
 import Circle from '~/components/Circle';
 import Link from 'next/link';
 
@@ -38,7 +38,7 @@ const LineSelector = (props) => {
             <Typography component="h4">
               {line.name}
               {' '}
-Line
+              Line
             </Typography>
           </div>
         </div>

--- a/components/LogoAndTitle.jsx
+++ b/components/LogoAndTitle.jsx
@@ -3,15 +3,13 @@ import {
   Card,
   CardMedia,
   CardContent,
-  Typography
+  Typography,
 } from '@material-ui/core';
-import {withStyles} from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/core/styles';
 import withWidth from '@material-ui/core/withWidth';
 import flowRight from 'lodash/flowRight';
 import Moment from 'react-moment';
-import moment from 'moment';
 import 'moment-timezone';
-import { linesById } from '~/helpers/LineInfo.js';
 import TooltipCustom from '~/components/TooltipCustom';
 
 const styles = theme => ({
@@ -27,14 +25,14 @@ const styles = theme => ({
     [theme.breakpoints.up('sm')]: {
       alignItems: 'center',
       margin: 10,
-      padding: 10
-    }
+      padding: 10,
+    },
   },
   cardContent: {
     [theme.breakpoints.down('xs')]: {
       padding: 0,
-      margin: 0
-    }
+      margin: 0,
+    },
   },
   logo: {
     padding: '0!important',
@@ -45,48 +43,52 @@ const styles = theme => ({
       width: 150,
       height: 150,
     },
-    marginRight: 25
+    marginRight: 25,
   },
   title: {
-    fontWeight: 500
+    fontWeight: 500,
   },
   updateTime: {
-    marginTop: '1em'
+    marginTop: '1em',
   },
   iconPosition: {
     position: 'absolute',
     top: 0,
-    right: 0
-  }
+    right: 0,
+  },
 });
 
 const LogoAndTitle = (props) => {
-  const { classes, timestamp, line, date } = props;
-  let defaultText = "";
+  const {
+    classes, timestamp, line, date, altImg, width, altText
+  } = props;
+  let defaultText = '';
   if (line === 'All') {
-    defaultText = date === 'Yesterday' ?
-      'How reliable was the LA Metro Network yesterday?' :
-      'How reliable is the LA Metro Network today?'
+    defaultText = date === 'Yesterday'
+      ? 'How reliable was the LA Metro Network yesterday?'
+      : 'How reliable is the LA Metro Network today?';
   } else if (date === 'Today') {
-    defaultText = `How reliable is the ${line} Line today?`
+    defaultText = `How reliable is the ${line} Line today?`;
   } else if (date === 'Yesterday') {
-    defaultText = `How reliable was the ${line} Line yesterday?`
+    defaultText = `How reliable was the ${line} Line yesterday?`;
   }
   return (
-    <Card elevation={0} className={ classes.card }>
-      <div className={ classes.iconPosition }>
-        <TooltipCustom title={(<Fragment>
+    <Card elevation={0} className={classes.card}>
+      <div className={classes.iconPosition}>
+        <TooltipCustom title={(
+          <Fragment>
             <Typography color="inherit">Update Timing</Typography>
             Latest statistics are provided roughly every 30 minutes.
-          </Fragment>)}>
-        </TooltipCustom>
+          </Fragment>
+)}
+        />
       </div>
-      <CardMedia component="img" className={classes.logo} src={ props.altImg ? props.altImg : `/static/images/logo_${props.line}.svg`}/>
-      <CardContent className={ classes.cardContent }>
-        <Typography variant={ props.width == 'xs' ? 'h6' : 'h4' } className={ classes.title }>
-          { props.altText ? props.altText : defaultText }
+      <CardMedia component="img" className={classes.logo} src={altImg || `/static/images/logo_${line}.svg`} />
+      <CardContent className={classes.cardContent}>
+        <Typography variant={width === 'xs' ? 'h6' : 'h4'} className={classes.title}>
+          { altText || defaultText }
         </Typography>
-        <Typography component="p" variant="body2" className={ classes.updateTime }>
+        <Typography component="p" variant="body2" className={classes.updateTime}>
           <b>Data from: </b>
           {
             timestamp
@@ -96,7 +98,7 @@ const LogoAndTitle = (props) => {
         </Typography>
       </CardContent>
     </Card>
-  )
-}
+  );
+};
 
 export default flowRight([withStyles(styles), withWidth()])(LogoAndTitle);

--- a/components/LogoAndTitle.jsx
+++ b/components/LogoAndTitle.jsx
@@ -60,7 +60,7 @@ const styles = theme => ({
 
 const LogoAndTitle = (props) => {
   const {
-    classes, timestamp, line, date, altImg, width, altText
+    classes, timestamp, line, date, altImg, width, altText,
   } = props;
   let defaultText = '';
   if (line === 'All') {

--- a/components/Nav.jsx
+++ b/components/Nav.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { AppBar, Typography, Toolbar } from '@material-ui/core';
 import { withStyles } from '@material-ui/core/styles';
 import withWidth from '@material-ui/core/withWidth';
@@ -40,7 +40,7 @@ const Nav = (props) => {
     navClasses,
     width,
     children,
-    handleMenuButton
+    handleMenuButton,
   } = props;
   return (
     <AppBar
@@ -65,6 +65,6 @@ const Nav = (props) => {
       </Toolbar>
     </AppBar>
   );
-}
+};
 
 export default flowRight([withStyles(styles), withWidth()])(Nav);

--- a/components/Nav.jsx
+++ b/components/Nav.jsx
@@ -8,7 +8,7 @@ import MenuIcon from '@material-ui/icons/Menu';
 import classNames from 'classnames';
 
 
-const styles = theme => ({
+const styles = () => ({
   menuButton: {
     marginLeft: 0,
     marginRight: 20,
@@ -29,37 +29,42 @@ const styles = theme => ({
     display: 'flex',
     flexDirection: 'row',
     justifyContent: 'flex-start',
-    alignItems: 'center'
-  }
+    alignItems: 'center',
+  },
 });
 
-class Nav extends Component {
-  render() {
-    const { classes } = this.props;
-    return (
-      <AppBar
-        position="fixed"
-        classes={{ root: classes.appBar, colorPrimary: classes.appBarColor }}
-      >
-        <Toolbar className={classNames(classes.containAppBar, this.props.navClasses)}>
-          <div className={ classes.leftSideDrawer }>
-            <IconButton
-              color="inherit"
-              aria-label="Open drawer"
-              onClick={this.props.handleMenuButton}
-              className={classes.menuButton}
-            >
-              <MenuIcon />
-            </IconButton>
-            <Typography variant={ this.props.width === 'xs' ? 'body1' : 'h5' } color="inherit">
-              {this.props.pageTitle}
-            </Typography>
-          </div>
-          {this.props.children}
-        </Toolbar>
-      </AppBar>
-    );
-  }
+const Nav = (props) => {
+  const {
+    classes,
+    pageTitle,
+    navClasses,
+    width,
+    children,
+    handleMenuButton
+  } = props;
+  return (
+    <AppBar
+      position="fixed"
+      classes={{ root: classes.appBar, colorPrimary: classes.appBarColor }}
+    >
+      <Toolbar className={classNames(classes.containAppBar, navClasses)}>
+        <div className={classes.leftSideDrawer}>
+          <IconButton
+            color="inherit"
+            aria-label="Open drawer"
+            onClick={handleMenuButton}
+            className={classes.menuButton}
+          >
+            <MenuIcon />
+          </IconButton>
+          <Typography variant={width === 'xs' ? 'body1' : 'h5'} color="inherit">
+            {pageTitle}
+          </Typography>
+        </div>
+        {children}
+      </Toolbar>
+    </AppBar>
+  );
 }
 
 export default flowRight([withStyles(styles), withWidth()])(Nav);

--- a/components/SimpleMenu.jsx
+++ b/components/SimpleMenu.jsx
@@ -27,9 +27,14 @@ class SimpleMenu extends React.Component {
     const { anchorEl } = this.state;
     const { menuItems, label, selected } = this.props;
     const menuItemList = menuItems.map((item, index) => (
-      <MenuItem onClick={() => this.handleClose(item, index)} key={item}>
+      <MenuItem
+        onClick={() => this.handleClose(item, index)}
+        key={item}
+      >
         { item }
-      </MenuItem>));
+      </MenuItem>
+    ));
+
     return (
       <span>
         <Button

--- a/components/SimpleMenu.jsx
+++ b/components/SimpleMenu.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import Button from '@material-ui/core/Button';
 import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
-import { Typography } from '@material-ui/core';
 
 class SimpleMenu extends React.Component {
   constructor(props) {
@@ -12,22 +11,25 @@ class SimpleMenu extends React.Component {
     };
   }
 
-  handleClick = event => {
+  handleClick = (event) => {
     this.setState({ anchorEl: event.currentTarget });
   };
 
   handleClose = (item, index) => {
+    const { handleMenuChange, menuItems } = this.props;
     this.setState({ anchorEl: null });
-    if (this.props.menuItems.includes(item)) {
-      this.props.handleMenuChange(item, index);
+    if (menuItems.includes(item)) {
+      handleMenuChange(item, index);
     }
   };
 
   render() {
     const { anchorEl } = this.state;
-    const menuItems = this.props.menuItems.map((item, index) => {
-      return <MenuItem onClick={() => this.handleClose(item, index)} key={item}>{ item }</MenuItem>
-    });
+    const { menuItems, label, selected } = this.props;
+    const menuItemList = menuItems.map((item, index) => (
+      <MenuItem onClick={() => this.handleClose(item, index)} key={item}>
+        { item }
+      </MenuItem>));
     return (
       <span>
         <Button
@@ -35,7 +37,8 @@ class SimpleMenu extends React.Component {
           aria-haspopup="true"
           onClick={this.handleClick}
         >
-          { this.props.label }{ this.props.menuItems[this.props.selected] }
+          { label }
+          { menuItems[selected] }
         </Button>
         <Menu
           id="simple-menu"
@@ -43,7 +46,7 @@ class SimpleMenu extends React.Component {
           open={Boolean(anchorEl)}
           onClose={this.handleClose}
         >
-          { menuItems }
+          { menuItemList }
         </Menu>
       </span>
     );

--- a/components/TablePaginationActions.jsx
+++ b/components/TablePaginationActions.jsx
@@ -1,0 +1,91 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { withStyles } from '@material-ui/core/styles';
+import IconButton from '@material-ui/core/IconButton';
+import FirstPageIcon from '@material-ui/icons/FirstPage';
+import KeyboardArrowLeft from '@material-ui/icons/KeyboardArrowLeft';
+import KeyboardArrowRight from '@material-ui/icons/KeyboardArrowRight';
+import LastPageIcon from '@material-ui/icons/LastPage';
+
+const styles = theme => ({
+  root: {
+    flexShrink: 0,
+    color: theme.palette.text.secondary,
+    marginLeft: theme.spacing.unit * 2.5,
+  },
+});
+
+class TablePaginationActions extends Component {
+  handleFirstPageButtonClick = (event) => {
+    const { onChangePage } = this.props;
+    onChangePage(event, 0);
+  };
+
+  handleBackButtonClick = (event) => {
+    const { onChangePage, page } = this.props;
+    onChangePage(event, page - 1);
+  };
+
+  handleNextButtonClick = (event) => {
+    const { onChangePage, page } = this.props;
+    onChangePage(event, page + 1);
+  };
+
+  handleLastPageButtonClick = (event) => {
+    const { onChangePage, rowsPerPage, count } = this.props;
+    onChangePage(
+      event,
+      Math.max(0, Math.ceil(count / rowsPerPage) - 1),
+    );
+  };
+
+  render() {
+    const {
+      classes, count, page, rowsPerPage, theme,
+    } = this.props;
+    return (
+      <div className={classes.root}>
+        <IconButton
+          onClick={this.handleFirstPageButtonClick}
+          disabled={page === 0}
+          aria-label="First Page"
+        >
+          {theme.direction === 'rtl' ? <LastPageIcon /> : <FirstPageIcon />}
+        </IconButton>
+        <IconButton
+          onClick={this.handleBackButtonClick}
+          disabled={page === 0}
+          aria-label="Previous Page"
+        >
+          {theme.direction === 'rtl' ? <KeyboardArrowRight /> : <KeyboardArrowLeft />}
+        </IconButton>
+        <IconButton
+          onClick={this.handleNextButtonClick}
+          disabled={page >= Math.ceil(count / rowsPerPage) - 1}
+          aria-label="Next Page"
+        >
+          {theme.direction === 'rtl' ? <KeyboardArrowLeft /> : <KeyboardArrowRight />}
+        </IconButton>
+        <IconButton
+          onClick={this.handleLastPageButtonClick}
+          disabled={page >= Math.ceil(count / rowsPerPage) - 1}
+          aria-label="Last Page"
+        >
+          {theme.direction === 'rtl' ? <FirstPageIcon /> : <LastPageIcon />}
+        </IconButton>
+      </div>
+    );
+  }
+}
+
+TablePaginationActions.propTypes = {
+  classes: PropTypes.object.isRequired,
+  count: PropTypes.number.isRequired,
+  onChangePage: PropTypes.func.isRequired,
+  page: PropTypes.number.isRequired,
+  theme: PropTypes.object.isRequired,
+};
+
+export default withStyles(styles, { withTheme: true })(
+  TablePaginationActions,
+);

--- a/components/TooltipCustom.jsx
+++ b/components/TooltipCustom.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {
   Tooltip,
 } from '@material-ui/core';
-import {withStyles} from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/core/styles';
 import InfoIcon from '@material-ui/icons/Info';
 import IconButton from '@material-ui/core/IconButton';
 
@@ -14,25 +14,30 @@ const styles = theme => ({
     fontSize: theme.typography.pxToRem(12),
     border: '1px solid #dadde9',
     '& b': {
-      fontWeight: theme.typography.fontWeightMedium
-    }
-  }
+      fontWeight: theme.typography.fontWeightMedium,
+    },
+  },
 });
 
 const TooltipCustom = (props) => {
   const defaultIcon = (
     <IconButton aria-label="Delete">
-      <InfoIcon/>
+      <InfoIcon />
     </IconButton>
   );
-  const { classes } = props;
+  const { classes, title, children } = props;
   return (
-    <Tooltip classes={{
-        tooltip: classes.htmlTooltip
-      }} title={ props.title } enterTouchDelay={0} leaveTouchDelay={2000}>
-      { props.children ? props.children : defaultIcon }
+    <Tooltip
+      classes={{
+        tooltip: classes.htmlTooltip,
+      }}
+      title={title}
+      enterTouchDelay={0}
+      leaveTouchDelay={2000}
+    >
+      { children || defaultIcon }
     </Tooltip>
-  )
-}
+  );
+};
 
 export default withStyles(styles)(TooltipCustom);

--- a/components/charts/Highchart.jsx
+++ b/components/charts/Highchart.jsx
@@ -1,19 +1,13 @@
 import React, { Component } from 'react';
-import { render } from 'react-dom';
 import Highcharts from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
 import moment from 'moment-timezone';
-import stopPositions from '../../helpers/StopPositions.js';
-import positionStops from '../../helpers/PositionStops.js';
+import stopPositions from '~/helpers/StopPositions';
+import positionStops from '~/helpers/PositionStops';
 
 class Highchart extends Component {
-  constructor(props) {
-    super(props);
-  }
-
   render() {
-    const line = this.props.line;
-    const direction = this.props.direction;
+    const { line, direction, min, max, observations } = this.props;
     const ticks = stopPositions[`${line}_${direction}`];
 
     // This technique is a bit of a hack!
@@ -22,20 +16,20 @@ class Highchart extends Component {
     // So we are creating a simplified dictionary derived from
     // the PositionStops object
     const positionsForLineDir = positionStops[`${line}_${direction}`];
-    const stopsByPosition = Object.keys(positionsForLineDir).map(pos => {
+    const stopsByPosition = Object.keys(positionsForLineDir).map((pos) => {
       const posStr = parseFloat(pos).toFixed(3);
-      const name = positionsForLineDir[pos]["stop_name"];
-      return { pos: posStr, name: name }
+      const name = positionsForLineDir[pos].stop_name;
+      return { pos: posStr, name };
     });
 
     const posToStopNames = stopsByPosition.reduce((map, obj) => {
       map[obj.pos] = obj.name;
-      return map
+      return map;
     }, {});
 
-    let tickPositions = Object.keys(ticks).map(stop => {
-      let pos = ticks[stop]["relative_position"];
-      return pos
+    const tickPositions = Object.keys(ticks).map((stop) => {
+      const pos = ticks[stop].relative_position;
+      return pos;
     });
 
     const options = {
@@ -46,25 +40,25 @@ class Highchart extends Component {
         series: {
           dataLabels: {
             enabled: false,
-          }
-        }
+          },
+        },
       },
       tooltip: {
         crosshairs: [true, true],
-        formatter: function() {
-          if (this.point.name) { 
+        formatter() {
+          if (this.point.name) {
             const time = `${moment(this.y)
               .tz('America/Los_Angeles')
-              .format('h:mma')}`
-            return `<b>${this.point.name}</b><br>Scheduled arrival: ${time}`
-          };
-          return false
-        }
+              .format('h:mma')}`;
+            return `<b>${this.point.name}</b><br>Scheduled arrival: ${time}`;
+          }
+          return false;
+        },
       },
       xAxis: {
         reversed: !!direction,
         gridLineWidth: 1,
-        tickPositions: tickPositions,
+        tickPositions,
         opposite: true,
         tickPosition: 'inside',
         min: 0,
@@ -72,20 +66,20 @@ class Highchart extends Component {
         labels: {
           rotation: -90,
           style: {
-            width: '200px'
+            width: '200px',
           },
-          formatter: function() {
+          formatter() {
             const index = this.value.toFixed(3);
-            const name = posToStopNames[index]
-            return name.replace(' Station', '')
-          }
-        }
+            const name = posToStopNames[index];
+            return name.replace(' Station', '');
+          },
+        },
       },
       yAxis: {
         reversed: true,
         type: 'datetime',
-        min: this.props.min,
-        max: this.props.max,
+        min,
+        max,
         title: {
           text: 'Time',
         },
@@ -93,23 +87,29 @@ class Highchart extends Component {
           formatter() {
             return `${moment(this.value)
               .tz('America/Los_Angeles')
-              .format('h:mma')}`
+              .format('h:mma')}`;
           },
         },
       },
-      series: this.props.observations,
+      series: observations,
       chart: {
         height: '500%',
         backgroundColor: '#f5f5f5',
         borderColor: '#999999',
         borderWidth: 2,
-        spacing: [50, 50, 50, 50]
+        spacing: [50, 50, 50, 50],
       },
       legend: {
         enabled: false,
       },
     };
-    return <HighchartsReact highcharts={Highcharts} options={options} callback={chart => {chart.reflow()}}/>;
+    return (
+      <HighchartsReact
+        highcharts={Highcharts}
+        options={options}
+        callback={(chart) => { chart.reflow(); }}
+      />
+    );
   }
 }
 

--- a/components/charts/Highchart.jsx
+++ b/components/charts/Highchart.jsx
@@ -7,7 +7,13 @@ import positionStops from '~/helpers/PositionStops';
 
 class Highchart extends Component {
   render() {
-    const { line, direction, min, max, observations } = this.props;
+    const {
+      line,
+      direction,
+      min,
+      max,
+      observations,
+    } = this.props;
     const ticks = stopPositions[`${line}_${direction}`];
 
     // This technique is a bit of a hack!
@@ -23,8 +29,9 @@ class Highchart extends Component {
     });
 
     const posToStopNames = stopsByPosition.reduce((map, obj) => {
-      map[obj.pos] = obj.name;
-      return map;
+      const newMap = map;
+      newMap[obj.pos] = obj.name;
+      return newMap;
     }, {});
 
     const tickPositions = Object.keys(ticks).map((stop) => {

--- a/components/charts/HistoryChart.jsx
+++ b/components/charts/HistoryChart.jsx
@@ -1,10 +1,9 @@
-import React from "react";
-import { Card } from '@material-ui/core';
+import React from 'react';
 import { withStyles } from '@material-ui/core/styles';
 import Highcharts from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
 
-const styles = theme => ({
+const styles = () => ({
   card: {
     maxWidth: 1200,
     margin: 'auto',
@@ -12,56 +11,59 @@ const styles = theme => ({
   },
 });
 
-class HistoryChart extends React.Component {
-  render() {
-    const { bgColor, 
-            chartFormat, 
-            classes, 
-            xTickFormat, 
-            yTickFormat, 
-            graphData, 
-            color, 
-            yAxis, 
-            secondSeries } = this.props;
-    
-    const series = [{
-          name: '',
-          color: color,
-          data: graphData
-        }]
-    if (secondSeries) series.push(secondSeries);
+const HistoryChart = (props) => {
+  const {
+    bgColor,
+    chartFormat,
+    classes,
+    xTickFormat,
+    yTickFormat,
+    graphData,
+    color,
+    yAxis,
+    secondSeries,
+  } = props;
 
-    const options = {
-        chart: {
-            type: chartFormat,
-            backgroundColor: bgColor,
-            plotBackgroundColor: bgColor
-        },
-        title: {
-          text: '',
-        },
-        legend: {
-          enabled: false
-        },
-        tooltip: {
-          enabled: false
-        },
-        xAxis: {
-          categories: xTickFormat
-        },
-        yAxis: {
-          title: '',
-          labels: yTickFormat,
-          min: 0,
-          max: yAxis === "Average Wait Time" ? 30 : 100
-        },
-        series: series
-    }
-    return <HighchartsReact 
-                 highcharts={Highcharts} 
-                 options={options}
-                 key={Math.random()} />
-  }
-}
+  const series = [{
+    name: '',
+    color,
+    data: graphData,
+  }];
+  if (secondSeries) series.push(secondSeries);
+
+  const options = {
+    chart: {
+      type: chartFormat,
+      backgroundColor: bgColor,
+      plotBackgroundColor: bgColor,
+    },
+    title: {
+      text: '',
+    },
+    legend: {
+      enabled: false,
+    },
+    tooltip: {
+      enabled: false,
+    },
+    xAxis: {
+      categories: xTickFormat,
+    },
+    yAxis: {
+      title: '',
+      labels: yTickFormat,
+      min: 0,
+      max: yAxis === 'Average Wait Time' ? 30 : 100,
+    },
+    series,
+  };
+  return (
+    <HighchartsReact
+      highcharts={Highcharts}
+      options={options}
+      key={Math.random()}
+    />
+  );
+};
 
 export default withStyles(styles)(HistoryChart);

--- a/components/charts/HistoryChart.jsx
+++ b/components/charts/HistoryChart.jsx
@@ -15,7 +15,6 @@ const HistoryChart = (props) => {
   const {
     bgColor,
     chartFormat,
-    classes,
     xTickFormat,
     yTickFormat,
     graphData,

--- a/components/charts/OnTimePie.jsx
+++ b/components/charts/OnTimePie.jsx
@@ -1,5 +1,4 @@
-import React, { Component } from 'react';
-import { render } from 'react-dom';
+import React, { Component } from 'react';2
 import Highcharts from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
 
@@ -9,80 +8,74 @@ const labelMap = {
   '3_min': 'Trains running between 2 - 3 minutes ahead or behind schedule',
   '4_min': 'Trains running between 3 - 4 minutes ahead or behind schedule',
   '5_min': 'Trains running between 4 - 5 minutes ahead or behind schedule',
-  '>5_mins': 'Trains running more than 5 minutes ahead or behind schedule'
+  '>5_mins': 'Trains running more than 5 minutes ahead or behind schedule',
 };
 
 class OnTimePie extends Component {
-  constructor(props) {
-    super(props)
-  }
-
   render() {
+    const { bins, total, selected } = this.props;
     const colors = [
       '#00ff00',
       '#ffff00',
       '#ff9900',
       '#ff0000',
       '#550055',
-      '#000000'
+      '#000000',
     ];
-    const bins = Object.keys(this.props.bins).map((key) => ({ name: key, value: this.props.bins[key] }));
+    const binList = Object.keys(bins).map(key => ({ name: key, value: bins[key] }));
 
-    const selectedValue = this.props.bins[this.props.selected];
-    const selectedPercent = Math.round(selectedValue / this.props.total * 1000) / 10;
+    const selectedValue = bins[selected];
+    const selectedPercent = Math.round(selectedValue / total * 1000) / 10;
 
     const separated = {};
-    separated[bins[0]["name"]] = Math.round(bins[0]["value"] / this.props.total * 1000) / 10;
-    bins.reduce((acc, currentValue) => {
-      separated[currentValue["name"]] = Math.round((currentValue["value"] - acc["value"]) / this.props.total * 1000) / 10;
-      return currentValue
+    separated[binList[0].name] = Math.round(binList[0].value / total * 1000) / 10;
+    binList.reduce((acc, currentValue) => {
+      separated[currentValue.name] = Math.round((currentValue.value - acc.value) / total * 1000) / 10;
+      return currentValue;
     });
-    separated[">5_mins"] = Math.round((this.props.total - bins[4]["value"]) / this.props.total * 1000) / 10;
-    const observations = Object.keys(separated).map((key, index) => {
-      return {
-        name: labelMap[key],
-        y: separated[key],
-        color: colors[index]
-      }
-    });
+    separated['>5_mins'] = Math.round((total - binList[4].value) / total * 1000) / 10;
+    const observations = Object.keys(separated).map((key, index) => ({
+      name: labelMap[key],
+      y: separated[key],
+      color: colors[index],
+    }));
     const options = {
       title: {
-        text: ''
+        text: '',
       },
       plotOptions: {
         pie: {
           dataLabels: {
-            enabled: false
+            enabled: false,
           },
-          size: '100%'
-        }
+          size: '100%',
+        },
       },
       tooltip: {
         crosshairs: [true, true],
-        formatter: function() {
+        formatter() {
           if (this.point.name) {
-            return `<b>${this.point.y}%</b><br>${this.point.name}`
-          } else {
-            return false
+            return `<b>${this.point.y}%</b><br>${this.point.name}`;
           }
-        }
+          return false;
+        },
       },
       series: [
         {
           innerSize: '45%',
           name: 'Bins',
-          data: observations.reverse()
+          data: observations.reverse(),
         },
         {
           innerSize: '80%',
           name: '',
-          data: [{y: 100, color: '#ffffff', name: ''}]
+          data: [{ y: 100, color: '#ffffff', name: '' }],
         },
         {
           innerSize: '90%',
           name: '',
-          data: [{y: selectedPercent, color: '#99e0ff', name: 'Trains within selected window'}, {y: (100 - selectedPercent), color: '#ffffff', name: ''}].reverse()
-        }
+          data: [{ y: selectedPercent, color: '#99e0ff', name: 'Trains within selected window' }, { y: (100 - selectedPercent), color: '#ffffff', name: '' }].reverse(),
+        },
       ],
       chart: {
         height: '100%',
@@ -92,11 +85,17 @@ class OnTimePie extends Component {
         backgroundColor: null,
       },
       credits: {
-        enabled: false
-      }
-    }
+        enabled: false,
+      },
+    };
 
-    return <HighchartsReact highcharts={Highcharts} options={options} callback={chart => {chart.reflow()}}/>;
+    return (
+      <HighchartsReact
+        highcharts={Highcharts}
+        options={options}
+        callback={(chart) => { chart.reflow(); }}
+      />
+    );
   }
 }
 

--- a/components/charts/OnTimePie.jsx
+++ b/components/charts/OnTimePie.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';2
+import React, { Component } from 'react';
 import Highcharts from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
 
@@ -30,7 +30,9 @@ class OnTimePie extends Component {
     const separated = {};
     separated[binList[0].name] = Math.round(binList[0].value / total * 1000) / 10;
     binList.reduce((acc, currentValue) => {
-      separated[currentValue.name] = Math.round((currentValue.value - acc.value) / total * 1000) / 10;
+      separated[currentValue.name] = Math.round(
+        (currentValue.value - acc.value) / total * 1000
+      ) / 10;
       return currentValue;
     });
     separated['>5_mins'] = Math.round((total - binList[4].value) / total * 1000) / 10;

--- a/components/charts/OnTimePie.jsx
+++ b/components/charts/OnTimePie.jsx
@@ -31,7 +31,7 @@ class OnTimePie extends Component {
     separated[binList[0].name] = Math.round(binList[0].value / total * 1000) / 10;
     binList.reduce((acc, currentValue) => {
       separated[currentValue.name] = Math.round(
-        (currentValue.value - acc.value) / total * 1000
+        (currentValue.value - acc.value) / total * 1000,
       ) / 10;
       return currentValue;
     });

--- a/components/scorecards/PerformanceScoreCard.jsx
+++ b/components/scorecards/PerformanceScoreCard.jsx
@@ -62,7 +62,7 @@ const PerformanceScoreCard = (props) => {
     ? formattedLineData[formattedLineData.length - 1][`${lineId.id}_lametro-rail`]
     : data;
   const score = Math.round(
-    scoreData.ontime[arrivalWindow] / scoreData.total_arrivals_analyzed * 1000
+    scoreData.ontime[arrivalWindow] / scoreData.total_arrivals_analyzed * 1000,
   ) / 10;
 
   return (
@@ -84,7 +84,7 @@ const PerformanceScoreCard = (props) => {
               Math.round(
                 1000
                 * scoreData.total_arrivals_analyzed
-                / scoreData.total_scheduled_arrivals
+                / scoreData.total_scheduled_arrivals,
               )
               / 10
             }

--- a/components/scorecards/PerformanceScoreCard.jsx
+++ b/components/scorecards/PerformanceScoreCard.jsx
@@ -1,19 +1,14 @@
-import React, { Component, Fragment } from 'react';
+import React, { Fragment } from 'react';
 import {
   Typography,
   Grid,
-  Tooltip,
   Card,
-  Divider
+  Divider,
 } from '@material-ui/core';
-import {withStyles} from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/core/styles';
 import TooltipCustom from '~/components/TooltipCustom';
 import OnTimePie from '~/components/charts/OnTimePie';
-import SimpleMenu from '~/components/SimpleMenu';
-import InfoIcon from '@material-ui/icons/Info';
-import IconButton from '@material-ui/core/IconButton';
 import Circle from '~/components/Circle';
-import Dropdown from '~/components/Dropdown';
 import ScoreCardHeader from '~/components/scorecards/ScoreCardHeader';
 import { linesByName, linesById } from '~/helpers/LineInfo';
 
@@ -21,152 +16,153 @@ import { linesByName, linesById } from '~/helpers/LineInfo';
 const styles = theme => ({
   progress: {
     margin: theme.spacing.unit * 2,
-    padding: theme.spacing.unit * 2
+    padding: theme.spacing.unit * 2,
   },
   card: {
     position: 'relative',
     padding: 0,
-    height: '100%'
+    height: '100%',
   },
   iconPosition: {
     position: 'absolute',
     top: 0,
-    right: 0
+    right: 0,
   },
   center: {
-    textAlign: 'center'
+    textAlign: 'center',
   },
   description: {
     textAlign: 'center',
-    marginTop: '1em'
+    marginTop: '1em',
   },
   spacer: {
-    margin: '2em 0'
+    margin: '2em 0',
   },
   maxWidth150: {
-    maxWidth: 150
+    maxWidth: 150,
   },
   cardContainer: {
-    height: 'calc(100% - 3em)'
+    height: 'calc(100% - 3em)',
   },
   performer: {
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
     flexDirection: 'row',
-    marginBottom: 10
+    marginBottom: 10,
   },
   separator: {
-    margin: 10
-  }
+    margin: 10,
+  },
 });
 
 const arrivalWindows = [
   {
     menuLabel: '1 minute',
-    dataLabel: '1_min'
+    dataLabel: '1_min',
   }, {
     menuLabel: '2 minutes',
-    dataLabel: '2_min'
+    dataLabel: '2_min',
   }, {
     menuLabel: '3 minutes',
-    dataLabel: '3_min'
+    dataLabel: '3_min',
   }, {
     menuLabel: '4 minutes',
-    dataLabel: '4_min'
+    dataLabel: '4_min',
   }, {
     menuLabel: '5 minutes',
-    dataLabel: '5_min'
-  }
+    dataLabel: '5_min',
+  },
 ];
 
-class PerformanceScoreCard extends Component {
-  constructor(props) {
-    super(props);
-    this.handleMenuChange = this.handleMenuChange.bind(this);
-    this.state = {
-      selectedArrivalWindow: {
-        index: 0,
-        menuLabel: arrivalWindows[0].menuLabel,
-        dataLabel: arrivalWindows[0].dataLabel
-      }
-    };
-  }
+const PerformanceScoreCard = (props) => {
+  const {
+    classes, data, currentLine, arrivalWindow, formattedLineData, width,
+  } = props;
+  const lineId = linesByName[currentLine];
+  const scoreData = lineId && lineId.id
+    ? formattedLineData[formattedLineData.length - 1][`${lineId.id}_lametro-rail`]
+    : data;
+  const score = Math.round(scoreData.ontime[arrivalWindow] / scoreData.total_arrivals_analyzed * 1000) / 10;
 
-  handleMenuChange(item, index) {
-    this.setState({
-      selectedArrivalWindow: {
-        index: index,
-        menuLabel: arrivalWindows[index].menuLabel,
-        dataLabel: arrivalWindows[index].dataLabel
-      }
-    })
-  }
-
-  render() {
-    const { classes, data, currentLine, arrivalWindow, formattedLineData, width } = this.props;
-    const lineId = linesByName[currentLine]
-    const scoreData = lineId && lineId.id ?
-      formattedLineData[formattedLineData.length - 1][`${lineId.id}_lametro-rail`] :
-      data
-    const score = Math.round(scoreData.ontime[arrivalWindow] / scoreData.total_arrivals_analyzed * 1000) / 10
-
-    return (
-      <Card elevation={1} className={ classes.card }>
-        <div className={ classes.iconPosition }>
-          <TooltipCustom title={(
-            <Fragment>
-              <Typography color="inherit">Performance Score</Typography>
-              This figure is based on {scoreData.total_arrivals_analyzed} train arrivals estimated so far out of {scoreData.total_scheduled_arrivals} scheduled for today ({ Math.round(1000 * scoreData.total_arrivals_analyzed / scoreData.total_scheduled_arrivals) / 10 }%). It includes trains both running ahead and behind schedule (early and late).
-            </Fragment>
-          )}/>
-        </div>
-        <ScoreCardHeader title="On-Time Performance" />
-        <Grid container item justify="center" alignItems="center" xs={12} className={ classes.cardContainer }>
-          <Grid item xs={6} className={ classes.maxWidth150 }>
-            <OnTimePie bins={scoreData.ontime} total={scoreData.total_arrivals_analyzed} selected={arrivalWindow}/>
-          </Grid>
-          <Grid item xs={6}>
-            <Typography variant={width === 'xs'
-                ? 'h3'
-                : 'h2'} component="p" className={ classes.center }>
-              {score}%
-            </Typography>
-          </Grid>
-          {scoreData.most_reliable && scoreData.least_reliable && (
-            <Grid item xs={12}>
-              <Divider light variant="middle" className={ classes.separator } />
-              <Typography color="textPrimary" gutterBottom className={classes.center}>
-                Most Reliable
-              </Typography>
-              <div className={classes.performer}>
-                <Circle color={linesById[scoreData.most_reliable[arrivalWindow].line.slice(0,3)].color} />
-                <Typography color="textSecondary" style={{ marginLeft: 10 }} component="h3">
-                  {linesById[scoreData.most_reliable[arrivalWindow].line.slice(0,3)].name}
-                  {' Line '}
-                  {(scoreData.most_reliable[arrivalWindow].percent_ontime * 100).toFixed(1)}
-                  {'% on-time'}
-                </Typography>
-              </div>
-              <Typography color="textPrimary" gutterBottom className={classes.center}>
-                Least Reliable
-              </Typography>
-              <div className={classes.performer}>
-                <Circle color={linesById[scoreData.least_reliable[arrivalWindow].line.slice(0,3)].color} />
-                <Typography color="textSecondary" style={{ marginLeft: 10 }} component="h3">
-                  {linesById[scoreData.least_reliable[arrivalWindow].line.slice(0,3)].name}
-                  {' Line '}
-                  {(scoreData.least_reliable[arrivalWindow].percent_ontime * 100).toFixed(1)}
-                  {'% on-time'}
-                </Typography>
-              </div>
-            </Grid>
-          )}
+  return (
+    <Card elevation={1} className={classes.card}>
+      <div className={classes.iconPosition}>
+        <TooltipCustom title={(
+          <Fragment>
+            <Typography color="inherit">Performance Score</Typography>
+            This figure is based on
+            {' '}
+            {scoreData.total_arrivals_analyzed}
+            {' '}
+train arrivals estimated so far out of
+            {' '}
+            {scoreData.total_scheduled_arrivals}
+            {' '}
+scheduled for today (
+            { Math.round(1000 * scoreData.total_arrivals_analyzed / scoreData.total_scheduled_arrivals) / 10 }
+%). It includes trains both running ahead and behind schedule (early and late).
+          </Fragment>
+        )}
+        />
+      </div>
+      <ScoreCardHeader title="On-Time Performance" />
+      <Grid container item justify="center" alignItems="center" xs={12} className={classes.cardContainer}>
+        <Grid item xs={6} className={classes.maxWidth150}>
+          <OnTimePie
+            bins={scoreData.ontime}
+            total={scoreData.total_arrivals_analyzed}
+            selected={arrivalWindow}
+          />
         </Grid>
-      </Card>
-    )
-  }
-
-}
+        <Grid item xs={6}>
+          <Typography
+            variant={width === 'xs'
+              ? 'h3'
+              : 'h2'}
+            component="p"
+            className={classes.center}
+          >
+            {score}
+%
+          </Typography>
+        </Grid>
+        {scoreData.most_reliable && scoreData.least_reliable && (
+          <Grid item xs={12}>
+            <Divider light variant="middle" className={classes.separator} />
+            <Typography color="textPrimary" gutterBottom className={classes.center}>
+              Most Reliable
+            </Typography>
+            <div className={classes.performer}>
+              <Circle
+                color={linesById[scoreData.most_reliable[arrivalWindow].line.slice(0, 3)].color}
+              />
+              <Typography color="textSecondary" style={{ marginLeft: 10 }} component="h3">
+                {linesById[scoreData.most_reliable[arrivalWindow].line.slice(0, 3)].name}
+                {' Line '}
+                {(scoreData.most_reliable[arrivalWindow].percent_ontime * 100).toFixed(1)}
+                {'% on-time'}
+              </Typography>
+            </div>
+            <Typography color="textPrimary" gutterBottom className={classes.center}>
+              Least Reliable
+            </Typography>
+            <div className={classes.performer}>
+              <Circle
+                color={linesById[scoreData.least_reliable[arrivalWindow].line.slice(0, 3)].color}
+              />
+              <Typography color="textSecondary" style={{ marginLeft: 10 }} component="h3">
+                {linesById[scoreData.least_reliable[arrivalWindow].line.slice(0, 3)].name}
+                {' Line '}
+                {(scoreData.least_reliable[arrivalWindow].percent_ontime * 100).toFixed(1)}
+                {'% on-time'}
+              </Typography>
+            </div>
+          </Grid>
+        )}
+      </Grid>
+    </Card>
+  );
+};
 
 export default withStyles(styles)(PerformanceScoreCard);

--- a/components/scorecards/PerformanceScoreCard.jsx
+++ b/components/scorecards/PerformanceScoreCard.jsx
@@ -56,25 +56,6 @@ const styles = theme => ({
   },
 });
 
-const arrivalWindows = [
-  {
-    menuLabel: '1 minute',
-    dataLabel: '1_min',
-  }, {
-    menuLabel: '2 minutes',
-    dataLabel: '2_min',
-  }, {
-    menuLabel: '3 minutes',
-    dataLabel: '3_min',
-  }, {
-    menuLabel: '4 minutes',
-    dataLabel: '4_min',
-  }, {
-    menuLabel: '5 minutes',
-    dataLabel: '5_min',
-  },
-];
-
 const PerformanceScoreCard = (props) => {
   const {
     classes, data, currentLine, arrivalWindow, formattedLineData, width,
@@ -83,7 +64,9 @@ const PerformanceScoreCard = (props) => {
   const scoreData = lineId && lineId.id
     ? formattedLineData[formattedLineData.length - 1][`${lineId.id}_lametro-rail`]
     : data;
-  const score = Math.round(scoreData.ontime[arrivalWindow] / scoreData.total_arrivals_analyzed * 1000) / 10;
+  const score = Math.round(
+    scoreData.ontime[arrivalWindow] / scoreData.total_arrivals_analyzed * 1000
+  ) / 10;
 
   return (
     <Card elevation={1} className={classes.card}>
@@ -100,7 +83,14 @@ train arrivals estimated so far out of
             {scoreData.total_scheduled_arrivals}
             {' '}
 scheduled for today (
-            { Math.round(1000 * scoreData.total_arrivals_analyzed / scoreData.total_scheduled_arrivals) / 10 }
+            {
+              Math.round(
+                1000
+                * scoreData.total_arrivals_analyzed
+                / scoreData.total_scheduled_arrivals
+              )
+              / 10
+            }
 %). It includes trains both running ahead and behind schedule (early and late).
           </Fragment>
         )}

--- a/components/scorecards/PerformanceScoreCard.jsx
+++ b/components/scorecards/PerformanceScoreCard.jsx
@@ -28,9 +28,6 @@ const styles = theme => ({
     top: 0,
     right: 0,
   },
-  center: {
-    textAlign: 'center',
-  },
   description: {
     textAlign: 'center',
     marginTop: '1em',
@@ -78,11 +75,11 @@ const PerformanceScoreCard = (props) => {
             {' '}
             {scoreData.total_arrivals_analyzed}
             {' '}
-train arrivals estimated so far out of
+            train arrivals estimated so far out of
             {' '}
             {scoreData.total_scheduled_arrivals}
             {' '}
-scheduled for today (
+            scheduled for today (
             {
               Math.round(
                 1000
@@ -91,7 +88,7 @@ scheduled for today (
               )
               / 10
             }
-%). It includes trains both running ahead and behind schedule (early and late).
+            %). It includes trains both running ahead and behind schedule (early and late).
           </Fragment>
         )}
         />
@@ -111,16 +108,16 @@ scheduled for today (
               ? 'h3'
               : 'h2'}
             component="p"
-            className={classes.center}
+            align="center"
           >
             {score}
-%
+            %
           </Typography>
         </Grid>
         {scoreData.most_reliable && scoreData.least_reliable && (
           <Grid item xs={12}>
             <Divider light variant="middle" className={classes.separator} />
-            <Typography color="textPrimary" gutterBottom className={classes.center}>
+            <Typography color="textPrimary" align="center">
               Most Reliable
             </Typography>
             <div className={classes.performer}>
@@ -134,7 +131,7 @@ scheduled for today (
                 {'% on-time'}
               </Typography>
             </div>
-            <Typography color="textPrimary" gutterBottom className={classes.center}>
+            <Typography color="textPrimary" align="center">
               Least Reliable
             </Typography>
             <div className={classes.performer}>

--- a/components/scorecards/ScoreCard.jsx
+++ b/components/scorecards/ScoreCard.jsx
@@ -40,7 +40,7 @@ const styles = theme => ({
 
 const ScoreCard = (props) => {
   const {
-    classes, headerText, title, tooltip, blockA, blockB, blockC, width
+    classes, headerText, title, tooltip, blockA, blockB, blockC, width,
   } = props;
   return (
     <Card elevation={1} classes={classes}>

--- a/components/scorecards/ScoreCard.jsx
+++ b/components/scorecards/ScoreCard.jsx
@@ -1,66 +1,71 @@
-import React, { Fragment} from 'react';
+import React, { Fragment } from 'react';
 import {
   Typography,
   Card,
-  CardMedia,
   Grid,
-  Divider
+  Divider,
 } from '@material-ui/core';
 import { withStyles } from '@material-ui/core/styles';
-import { linesById } from '~/helpers/LineInfo.js';
-import Circle from '~/components/Circle';
 import TooltipCustom from '~/components/TooltipCustom';
 import ScoreCardHeader from '~/components/scorecards/ScoreCardHeader';
 
 const styles = theme => ({
   root: {
-    //padding: theme.spacing.unit * 2,
+    // padding: theme.spacing.unit * 2,
     padding: 0,
     textAlign: 'center',
     color: theme.palette.text.secondary,
     position: 'relative',
-    height: '100%'
+    height: '100%',
   },
   iconPosition: {
     position: 'absolute',
     top: 0,
-    right: 0
+    right: 0,
   },
   performer: {
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
     flexDirection: 'row',
-    marginBottom: 10
+    marginBottom: 10,
   },
   container: {
-    height: 'calc(100% - 3em)'
+    height: 'calc(100% - 3em)',
   },
   separator: {
-    margin: 10
-  }
+    margin: 10,
+  },
 });
 
 const ScoreCard = (props) => {
-  const { classes, headerText, title, tooltip, blockA, blockB, blockC } = props;
+  const {
+    classes, headerText, title, tooltip, blockA, blockB, blockC, width
+  } = props;
   return (
     <Card elevation={1} classes={classes}>
-      <div className={ classes.iconPosition }>
-        <TooltipCustom title={(<Fragment>
+      <div className={classes.iconPosition}>
+        <TooltipCustom title={(
+          <Fragment>
             <Typography color="inherit">{tooltip.header}</Typography>
             {tooltip.content}
           </Fragment>
-        )}/>
+        )}
+        />
       </div>
       <ScoreCardHeader title={headerText} />
-      <Grid container justifyContent="center" alignItems="center" className={ classes.separator }>
-        <Grid item xs={12} className={ classes.separator }>
-          <Typography variant={props.width === 'xs'
-            ? 'h3'
-            : 'h2'} component="p" align="center">
-          {title}
+      <Grid container justifyContent="center" alignItems="center" className={classes.separator}>
+        <Grid item xs={12} className={classes.separator}>
+          <Typography
+            variant={width === 'xs'
+              ? 'h3'
+              : 'h2'}
+            component="p"
+            align="center"
+          >
+            {title}
           </Typography>
-          <Divider light variant="middle" className={ classes.separator } />
+          <Divider light variant="middle" className={classes.separator} />
         </Grid>
         {blockA && (
           <Grid item xs={12}>
@@ -70,20 +75,20 @@ const ScoreCard = (props) => {
           </Grid>
         )}
         {blockB && (
-            <Grid item xs={12} className={ classes.separator }>
-            <Divider light variant="middle" className={ classes.separator } />
-            <Typography color="textPrimary" gutterBottom>
-              {blockB}
-            </Typography>
-          </Grid>
+        <Grid item xs={12} className={classes.separator}>
+          <Divider light variant="middle" className={classes.separator} />
+          <Typography color="textPrimary" gutterBottom>
+            {blockB}
+          </Typography>
+        </Grid>
         )}
         {blockC && (
-            <Grid item xs={12} className={ classes.separator }>
-            <Divider light variant="middle" className={ classes.separator } />
-            <Typography color="textPrimary" gutterBottom>
-              {blockC}
-            </Typography>
-          </Grid>
+        <Grid item xs={12} className={classes.separator}>
+          <Divider light variant="middle" className={classes.separator} />
+          <Typography color="textPrimary" gutterBottom>
+            {blockC}
+          </Typography>
+        </Grid>
         )}
       </Grid>
     </Card>

--- a/components/scorecards/ScoreCardHeader.jsx
+++ b/components/scorecards/ScoreCardHeader.jsx
@@ -1,28 +1,25 @@
-import React, { Fragment} from 'react';
+import React from 'react';
 import {
-  Typography,
-  CardHeader
+  CardHeader,
 } from '@material-ui/core';
 import { withStyles } from '@material-ui/core/styles';
 
-const styles = theme => ({
+const styles = () => ({
   root: {
     backgroundColor: '#eee',
-    height: '3em'
+    height: '3em',
   },
   title: {
     fontSize: '1em',
-    textAlign: 'center'
-  }
+    textAlign: 'center',
+  },
 });
 
 const ScoreCardHeader = (props) => {
   const { title, classes } = props;
   return (
-    <CardHeader classes={ classes } title={ title }>
-    </CardHeader>
-  )
-}
+    <CardHeader classes={classes} title={title} />
+  );
+};
 
 export default withStyles(styles)(ScoreCardHeader);
-

--- a/components/scorecards/WaitTimeScoreCard.jsx
+++ b/components/scorecards/WaitTimeScoreCard.jsx
@@ -1,15 +1,17 @@
 import React, { Fragment } from 'react';
 import {
   Typography,
-  Card,
   Grid,
+  Card,
   Divider,
 } from '@material-ui/core';
 import { withStyles } from '@material-ui/core/styles';
-import { linesById, linesByName } from '~/helpers/LineInfo';
-import Circle from '~/components/Circle';
 import TooltipCustom from '~/components/TooltipCustom';
+import OnTimePie from '~/components/charts/OnTimePie';
+import Circle from '~/components/Circle';
 import ScoreCardHeader from '~/components/scorecards/ScoreCardHeader';
+import { linesByName, linesById } from '~/helpers/LineInfo';
+
 
 const styles = theme => ({
   root: {
@@ -42,32 +44,36 @@ const styles = theme => ({
 
 const WaitTimeScoreCard = (props) => {
   const {
-    classes, data, currentLine, formattedLineData, width,
+    classes,
+    data,
+    currentLine,
+    formattedLineData,
+    width,
   } = props;
   const lineId = linesByName[currentLine];
   const waitData = lineId && lineId.id
     ? formattedLineData[formattedLineData.length - 1][`${lineId.id}_lametro-rail`]
     : data;
+
   return (
-    <Card elevation={1} classes={classes}>
+    <Card elevation={1} className={classes.card}>
       <div className={classes.iconPosition}>
         <TooltipCustom title={(
           <Fragment>
             <Typography color="inherit">Average Wait Time</Typography>
             This is an average over all stop intervals measured for the day so far.
-            Obviously, this interval should be split by time of day since trains
-            run more frequently during peak times.
-            Feature coming soon!
+            Obviously, this interval should be split by time of day since trains run
+            more frequently during peak times. Feature coming soon!
           </Fragment>
         )}
         />
       </div>
       <ScoreCardHeader title="Average Wait Time" />
-      <Grid container justifyContent="center" alignItems="center" className={classes.separator}>
+      <Grid container className={classes.separator}>
         <Grid item xs={6}>
           <img
-            src="/static/images/waiting.svg"
             alt="waiting"
+            src="/static/images/waiting.svg"
           />
         </Grid>
         <Grid item xs={6}>
@@ -87,7 +93,7 @@ const WaitTimeScoreCard = (props) => {
         {waitData.most_frequent && (
           <Grid item xs={12}>
             <Divider light variant="middle" className={classes.separator} />
-            <Typography color="textPrimary" gutterBottom>
+            <Typography color="textPrimary" align="center">
               Most Frequent
             </Typography>
             <div className={classes.performer}>
@@ -103,7 +109,7 @@ const WaitTimeScoreCard = (props) => {
         )}
         {waitData.least_frequent && (
           <Grid item xs={12}>
-            <Typography color="textPrimary" gutterBottom>
+            <Typography color="textPrimary" align="center">
               Least Frequent
             </Typography>
             <div className={classes.performer}>

--- a/components/scorecards/WaitTimeScoreCard.jsx
+++ b/components/scorecards/WaitTimeScoreCard.jsx
@@ -7,11 +7,9 @@ import {
 } from '@material-ui/core';
 import { withStyles } from '@material-ui/core/styles';
 import TooltipCustom from '~/components/TooltipCustom';
-import OnTimePie from '~/components/charts/OnTimePie';
 import Circle from '~/components/Circle';
 import ScoreCardHeader from '~/components/scorecards/ScoreCardHeader';
 import { linesByName, linesById } from '~/helpers/LineInfo';
-
 
 const styles = theme => ({
   root: {

--- a/components/scorecards/WaitTimeScoreCard.jsx
+++ b/components/scorecards/WaitTimeScoreCard.jsx
@@ -1,73 +1,81 @@
-import React, { Fragment} from 'react';
+import React, { Fragment } from 'react';
 import {
   Typography,
   Card,
-  CardMedia,
   Grid,
-  Divider
+  Divider,
 } from '@material-ui/core';
 import { withStyles } from '@material-ui/core/styles';
-import { linesById, linesByName } from '~/helpers/LineInfo.js';
+import { linesById, linesByName } from '~/helpers/LineInfo';
 import Circle from '~/components/Circle';
 import TooltipCustom from '~/components/TooltipCustom';
 import ScoreCardHeader from '~/components/scorecards/ScoreCardHeader';
 
 const styles = theme => ({
   root: {
-    //padding: theme.spacing.unit * 2,
+    // padding: theme.spacing.unit * 2,
     padding: 0,
     textAlign: 'center',
     color: theme.palette.text.secondary,
     position: 'relative',
-    height: '100%'
+    height: '100%',
   },
   iconPosition: {
     position: 'absolute',
     top: 0,
-    right: 0
+    right: 0,
   },
   performer: {
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
     flexDirection: 'row',
-    marginBottom: 10
+    marginBottom: 10,
   },
   container: {
-    height: 'calc(100% - 3em)'
+    height: 'calc(100% - 3em)',
   },
   separator: {
-    margin: 10
-  }
+    margin: 10,
+  },
 });
 
 const WaitTimeScoreCard = (props) => {
-  const { classes, data, currentLine, formattedLineData, width } = props;
-  const lineId = linesByName[currentLine]
-  const waitData = lineId && lineId.id ?
-    formattedLineData[formattedLineData.length - 1][`${lineId.id}_lametro-rail`] :
-    data
+  const {
+    classes, data, currentLine, formattedLineData, width,
+  } = props;
+  const lineId = linesByName[currentLine];
+  const waitData = lineId && lineId.id
+    ? formattedLineData[formattedLineData.length - 1][`${lineId.id}_lametro-rail`]
+    : data;
   return (
     <Card elevation={1} classes={classes}>
-      <div className={ classes.iconPosition }>
-        <TooltipCustom title={(<Fragment>
+      <div className={classes.iconPosition}>
+        <TooltipCustom title={(
+          <Fragment>
             <Typography color="inherit">Average Wait Time</Typography>
             This is an average over all stop intervals measured for the day so far. Obviously, this interval should be split by time of day since trains run more frequently during peak times. Feature coming soon!
           </Fragment>
-        )}/>
+        )}
+        />
       </div>
       <ScoreCardHeader title="Average Wait Time" />
-      <Grid container justifyContent="center" alignItems="center" className={ classes.separator }>
+      <Grid container justifyContent="center" alignItems="center" className={classes.separator}>
         <Grid item xs={6}>
           <img
             src="/static/images/waiting.svg"
+            alt="waiting"
           />
         </Grid>
         <Grid item xs={6}>
-          <Typography variant={width === 'xs'
-            ? 'h3'
-            : 'h1'} component="p" align="center">
-          {Math.round(waitData.mean_time_between / 60)}
+          <Typography
+            variant={width === 'xs'
+              ? 'h3'
+              : 'h1'}
+            component="p"
+            align="center"
+          >
+            {Math.round(waitData.mean_time_between / 60)}
           </Typography>
           <Typography variant="h5" align="center">
             minutes
@@ -75,7 +83,7 @@ const WaitTimeScoreCard = (props) => {
         </Grid>
         {waitData.most_frequent && (
           <Grid item xs={12}>
-            <Divider light variant="middle" className={ classes.separator } />
+            <Divider light variant="middle" className={classes.separator} />
             <Typography color="textPrimary" gutterBottom>
               Most Frequent
             </Typography>

--- a/components/scorecards/WaitTimeScoreCard.jsx
+++ b/components/scorecards/WaitTimeScoreCard.jsx
@@ -54,7 +54,10 @@ const WaitTimeScoreCard = (props) => {
         <TooltipCustom title={(
           <Fragment>
             <Typography color="inherit">Average Wait Time</Typography>
-            This is an average over all stop intervals measured for the day so far. Obviously, this interval should be split by time of day since trains run more frequently during peak times. Feature coming soon!
+            This is an average over all stop intervals measured for the day so far.
+            Obviously, this interval should be split by time of day since trains
+            run more frequently during peak times.
+            Feature coming soon!
           </Fragment>
         )}
         />

--- a/helpers/DataFinder.js
+++ b/helpers/DataFinder.js
@@ -1,27 +1,24 @@
 import S3 from 'aws-sdk/clients/s3';
+
 const s3 = new S3();
 
-const whenListAllObjects = (params) => {
-  return new Promise((resolve) => {
-    s3.makeUnauthenticatedRequest('listObjects', params, function (err, data) {
-      if (err) console.log(err);
-      else {
-        const objects = data.Contents.map(file => file.Key).sort();
-        resolve(objects);
-      };
-    });
+const whenListAllObjects = params => new Promise((resolve) => {
+  s3.makeUnauthenticatedRequest('listObjects', params, (err, data) => {
+    if (err) console.log(err);
+    else {
+      const objects = data.Contents.map(file => file.Key).sort();
+      resolve(objects);
+    }
   });
-};
+});
 
-const whenGotS3Object = (params) => {
-  return new Promise((resolve) => {
-    s3.makeUnauthenticatedRequest('getObject', params, function (err, data) {
-      if (err) console.log(err);
-      else {
-        resolve(JSON.parse(data.Body.toString()));
-      };
-    });
+const whenGotS3Object = params => new Promise((resolve) => {
+  s3.makeUnauthenticatedRequest('getObject', params, (err, data) => {
+    if (err) console.log(err);
+    else {
+      resolve(JSON.parse(data.Body.toString()));
+    }
   });
-};
+});
 
 export { whenGotS3Object, whenListAllObjects };

--- a/helpers/Directions.js
+++ b/helpers/Directions.js
@@ -1,14 +1,14 @@
 export default {
-  "801_0": "7th Street / Metro Center Station",
-  "802_0": "Union Station",
-  "803_0": "Norwalk Station",
-  "804_0": "APU / Citrus College Station",
-  "805_0": "Union Station",
-  "806_0": "7th Street / Metro Center Station",
-  "801_1": "Downtown Long Beach Station",
-  "802_1": "North Hollywood Station",
-  "803_1": "Redondo Beach Station",
-  "804_1": "Atlantic Station",
-  "805_1": "Wilshire / Western Station",
-  "806_1": "Downtown Santa Monica Station"
-}
+  '801_0': '7th Street / Metro Center Station',
+  '802_0': 'Union Station',
+  '803_0': 'Norwalk Station',
+  '804_0': 'APU / Citrus College Station',
+  '805_0': 'Union Station',
+  '806_0': '7th Street / Metro Center Station',
+  '801_1': 'Downtown Long Beach Station',
+  '802_1': 'North Hollywood Station',
+  '803_1': 'Redondo Beach Station',
+  '804_1': 'Atlantic Station',
+  '805_1': 'Wilshire / Western Station',
+  '806_1': 'Downtown Santa Monica Station',
+};

--- a/helpers/LineInfo.js
+++ b/helpers/LineInfo.js
@@ -10,30 +10,30 @@ const lines = [
 ];
 
 const linesById = {
-  801: { name: 'Blue', color: '#2461aa'},
-  802: { name: 'Red', color: '#fc1920'},
-  803: { name: 'Green', color: '#6bbc46'},
-  804: { name: 'Gold', color: '#ffb200'},
-  805: { name: 'Purple', color: '#9561a8'},
-  806: { name: 'Expo', color: '#51c8e8'},
+  801: { name: 'Blue', color: '#2461aa' },
+  802: { name: 'Red', color: '#fc1920' },
+  803: { name: 'Green', color: '#6bbc46' },
+  804: { name: 'Gold', color: '#ffb200' },
+  805: { name: 'Purple', color: '#9561a8' },
+  806: { name: 'Expo', color: '#51c8e8' },
 };
 
 const linesByName = {
-  Blue: { id: 801, color: '#2461aa'},
-  Red: { id: 802, color: '#fc1920'},
-  Green: { id: 803, color: '#6bbc46'},
-  Gold: { id: 804, color: '#ffb200'},
-  Purple: { id: 805, color: '#9561a8'},
-  Expo: { id: 806, color: '#51c8e8'},
-  "All Lines": { color: '#dddddd'}
+  Blue: { id: 801, color: '#2461aa' },
+  Red: { id: 802, color: '#fc1920' },
+  Green: { id: 803, color: '#6bbc46' },
+  Gold: { id: 804, color: '#ffb200' },
+  Purple: { id: 805, color: '#9561a8' },
+  Expo: { id: 806, color: '#51c8e8' },
+  'All Lines': { color: '#dddddd' },
 };
 
-const lineLinks = (classes) => ( 
-  lines.map((metLine,i) => (
-      <MenuItem value={`${metLine.name}`} key={i}>
-        <div style={{display: "flex", alignItems: "center"}}>
+const lineLinks = classes => (
+  lines.map((metLine, i) => (
+    <MenuItem value={`${metLine.name}`} key={i}>
+      <div style={{ display: 'flex', alignItems: 'center' }}>
         <ListItemAvatar>
-          <Avatar className={ classes.avatar }>
+          <Avatar className={classes.avatar}>
             <div
               style={{
                 backgroundColor: metLine.color,
@@ -47,9 +47,11 @@ const lineLinks = (classes) => (
           </Avatar>
         </ListItemAvatar>
         {metLine.name}
-        </div>
-      </MenuItem>
+      </div>
+    </MenuItem>
   ))
- )
+);
 
-export { lines, linesById, linesByName, lineLinks };
+export {
+  lines, linesById, linesByName, lineLinks,
+};

--- a/helpers/PositionStops.js
+++ b/helpers/PositionStops.js
@@ -1,846 +1,846 @@
 export default {
-  "801_0": {
-    "0.0": {
-      "stop_id": 80101,
-      "stop_name": "Downtown Long Beach Station"
+  '801_0': {
+    '0.0': {
+      stop_id: 80101,
+      stop_name: 'Downtown Long Beach Station',
     },
-    "0.015038366": {
-      "stop_id": 80102,
-      "stop_name": "Pacific Ave Station"
+    0.015038366: {
+      stop_id: 80102,
+      stop_name: 'Pacific Ave Station',
     },
-    "0.0568415579": {
-      "stop_id": 80105,
-      "stop_name": "Anaheim Street Station"
+    0.0568415579: {
+      stop_id: 80105,
+      stop_name: 'Anaheim Street Station',
     },
-    "0.0790934445": {
-      "stop_id": 80106,
-      "stop_name": "Pacific Coast Hwy Station"
+    0.0790934445: {
+      stop_id: 80106,
+      stop_name: 'Pacific Coast Hwy Station',
     },
-    "0.1346358563": {
-      "stop_id": 80107,
-      "stop_name": "Willow Street Station"
+    0.1346358563: {
+      stop_id: 80107,
+      stop_name: 'Willow Street Station',
     },
-    "0.178332583": {
-      "stop_id": 80108,
-      "stop_name": "Wardlow Station"
+    0.178332583: {
+      stop_id: 80108,
+      stop_name: 'Wardlow Station',
     },
-    "0.2769232974": {
-      "stop_id": 80109,
-      "stop_name": "Del Amo Station"
+    0.2769232974: {
+      stop_id: 80109,
+      stop_name: 'Del Amo Station',
     },
-    "0.3692947148": {
-      "stop_id": 80110,
-      "stop_name": "Artesia Station"
+    0.3692947148: {
+      stop_id: 80110,
+      stop_name: 'Artesia Station',
     },
-    "0.4352200647": {
-      "stop_id": 80111,
-      "stop_name": "Compton Station"
+    0.4352200647: {
+      stop_id: 80111,
+      stop_name: 'Compton Station',
     },
-    "0.5600720018": {
-      "stop_id": 80112,
-      "stop_name": "Willowbrook - Rosa Parks Station - Metro Blue Line"
+    0.5600720018: {
+      stop_id: 80112,
+      stop_name: 'Willowbrook - Rosa Parks Station - Metro Blue Line',
     },
-    "0.6074913717": {
-      "stop_id": 80113,
-      "stop_name": "103rd Street / Watts Towers  Station"
+    0.6074913717: {
+      stop_id: 80113,
+      stop_name: '103rd Street / Watts Towers  Station',
     },
-    "0.6607977235": {
-      "stop_id": 80114,
-      "stop_name": "Firestone Station"
+    0.6607977235: {
+      stop_id: 80114,
+      stop_name: 'Firestone Station',
     },
-    "0.704102429": {
-      "stop_id": 80115,
-      "stop_name": "Florence Station"
+    0.704102429: {
+      stop_id: 80115,
+      stop_name: 'Florence Station',
     },
-    "0.7501449099": {
-      "stop_id": 80116,
-      "stop_name": "Slauson Station"
+    0.7501449099: {
+      stop_id: 80116,
+      stop_name: 'Slauson Station',
     },
-    "0.7935442741": {
-      "stop_id": 80117,
-      "stop_name": "Vernon Station"
+    0.7935442741: {
+      stop_id: 80117,
+      stop_name: 'Vernon Station',
     },
-    "0.8448266783": {
-      "stop_id": 80118,
-      "stop_name": "Washington Station"
+    0.8448266783: {
+      stop_id: 80118,
+      stop_name: 'Washington Station',
     },
-    "0.8903047134": {
-      "stop_id": 80119,
-      "stop_name": "San Pedro Street Station"
+    0.8903047134: {
+      stop_id: 80119,
+      stop_name: 'San Pedro Street Station',
     },
-    "0.9369389647": {
-      "stop_id": 80120,
-      "stop_name": "Grand / LATTC Station"
+    0.9369389647: {
+      stop_id: 80120,
+      stop_name: 'Grand / LATTC Station',
     },
-    "0.9664983021": {
-      "stop_id": 80121,
-      "stop_name": "Pico Station"
+    0.9664983021: {
+      stop_id: 80121,
+      stop_name: 'Pico Station',
     },
-    "0.999394812": {
-      "stop_id": 80122,
-      "stop_name": "7th Street / Metro Center Station - Metro Blue & Expo Lines"
-    }
+    0.999394812: {
+      stop_id: 80122,
+      stop_name: '7th Street / Metro Center Station - Metro Blue & Expo Lines',
+    },
   },
-  "802_0": {
-    "0.011481427": {
-      "stop_id": 80201,
-      "stop_name": "North Hollywood Station"
+  '802_0': {
+    0.011481427: {
+      stop_id: 80201,
+      stop_name: 'North Hollywood Station',
     },
-    "0.1486530455": {
-      "stop_id": 80202,
-      "stop_name": "Universal / Studio City Station"
+    0.1486530455: {
+      stop_id: 80202,
+      stop_name: 'Universal / Studio City Station',
     },
-    "0.3588269453": {
-      "stop_id": 80203,
-      "stop_name": "Hollywood / Highland Station"
+    0.3588269453: {
+      stop_id: 80203,
+      stop_name: 'Hollywood / Highland Station',
     },
-    "0.4152410658": {
-      "stop_id": 80204,
-      "stop_name": "Hollywood / Vine Station"
+    0.4152410658: {
+      stop_id: 80204,
+      stop_name: 'Hollywood / Vine Station',
     },
-    "0.4872420162": {
-      "stop_id": 80205,
-      "stop_name": "Hollywood / Western Station"
+    0.4872420162: {
+      stop_id: 80205,
+      stop_name: 'Hollywood / Western Station',
     },
-    "0.5674176048": {
-      "stop_id": 80206,
-      "stop_name": "Vermont / Sunset Station"
+    0.5674176048: {
+      stop_id: 80206,
+      stop_name: 'Vermont / Sunset Station',
     },
-    "0.6003228502": {
-      "stop_id": 80207,
-      "stop_name": "Vermont / Santa Monica Station"
+    0.6003228502: {
+      stop_id: 80207,
+      stop_name: 'Vermont / Santa Monica Station',
     },
-    "0.6567993483": {
-      "stop_id": 80208,
-      "stop_name": "Vermont / Beverly Station"
+    0.6567993483: {
+      stop_id: 80208,
+      stop_name: 'Vermont / Beverly Station',
     },
-    "0.7219057515": {
-      "stop_id": 80209,
-      "stop_name": "Wilshire / Vermont Station"
+    0.7219057515: {
+      stop_id: 80209,
+      stop_name: 'Wilshire / Vermont Station',
     },
-    "0.7932260967": {
-      "stop_id": 80210,
-      "stop_name": "Westlake / MacArthur Park Station"
+    0.7932260967: {
+      stop_id: 80210,
+      stop_name: 'Westlake / MacArthur Park Station',
     },
-    "0.8694323818": {
-      "stop_id": 80211,
-      "stop_name": "7th Street / Metro Center Station - Metro Red & Purple Lines"
+    0.8694323818: {
+      stop_id: 80211,
+      stop_name: '7th Street / Metro Center Station - Metro Red & Purple Lines',
     },
-    "0.9063520082": {
-      "stop_id": 80212,
-      "stop_name": "Pershing Square Station"
+    0.9063520082: {
+      stop_id: 80212,
+      stop_name: 'Pershing Square Station',
     },
-    "0.9385534541": {
-      "stop_id": 80213,
-      "stop_name": "Civic Center / Grand Park Station"
+    0.9385534541: {
+      stop_id: 80213,
+      stop_name: 'Civic Center / Grand Park Station',
     },
-    "0.9947256652": {
-      "stop_id": 80214,
-      "stop_name": "Union Station - Metro Red & Purple Lines"
-    }
+    0.9947256652: {
+      stop_id: 80214,
+      stop_name: 'Union Station - Metro Red & Purple Lines',
+    },
   },
-  "803_0": {
-    "0.0028660968": {
-      "stop_id": 80301,
-      "stop_name": "Redondo Beach Station"
+  '803_0': {
+    0.0028660968: {
+      stop_id: 80301,
+      stop_name: 'Redondo Beach Station',
     },
-    "0.0550048966": {
-      "stop_id": 80302,
-      "stop_name": "Douglas Station"
+    0.0550048966: {
+      stop_id: 80302,
+      stop_name: 'Douglas Station',
     },
-    "0.0910830652": {
-      "stop_id": 80303,
-      "stop_name": "El Segundo Station"
+    0.0910830652: {
+      stop_id: 80303,
+      stop_name: 'El Segundo Station',
     },
-    "0.1134165058": {
-      "stop_id": 80304,
-      "stop_name": "Mariposa Station"
+    0.1134165058: {
+      stop_id: 80304,
+      stop_name: 'Mariposa Station',
     },
-    "0.1578694227": {
-      "stop_id": 80305,
-      "stop_name": "Aviation / LAX Station"
+    0.1578694227: {
+      stop_id: 80305,
+      stop_name: 'Aviation / LAX Station',
     },
-    "0.2353916104": {
-      "stop_id": 80306,
-      "stop_name": "Hawthorne / Lennox Station"
+    0.2353916104: {
+      stop_id: 80306,
+      stop_name: 'Hawthorne / Lennox Station',
     },
-    "0.3164939375": {
-      "stop_id": 80307,
-      "stop_name": "Crenshaw Station"
+    0.3164939375: {
+      stop_id: 80307,
+      stop_name: 'Crenshaw Station',
     },
-    "0.4209828433": {
-      "stop_id": 80308,
-      "stop_name": "Vermont / Athens Station"
+    0.4209828433: {
+      stop_id: 80308,
+      stop_name: 'Vermont / Athens Station',
     },
-    "0.4526033946": {
-      "stop_id": 80309,
-      "stop_name": "Harbor Freeway Station"
+    0.4526033946: {
+      stop_id: 80309,
+      stop_name: 'Harbor Freeway Station',
     },
-    "0.5001332559": {
-      "stop_id": 80310,
-      "stop_name": "Avalon Station"
+    0.5001332559: {
+      stop_id: 80310,
+      stop_name: 'Avalon Station',
     },
-    "0.5811743311": {
-      "stop_id": 80311,
-      "stop_name": "Willowbrook - Rosa Parks Station - Metro Green Line"
+    0.5811743311: {
+      stop_id: 80311,
+      stop_name: 'Willowbrook - Rosa Parks Station - Metro Green Line',
     },
-    "0.6680095776": {
-      "stop_id": 80312,
-      "stop_name": "Long Beach Blvd Station"
+    0.6680095776: {
+      stop_id: 80312,
+      stop_name: 'Long Beach Blvd Station',
     },
-    "0.8822319642": {
-      "stop_id": 80313,
-      "stop_name": "Lakewood Blvd Station"
+    0.8822319642: {
+      stop_id: 80313,
+      stop_name: 'Lakewood Blvd Station',
     },
-    "0.9890352454": {
-      "stop_id": 80314,
-      "stop_name": "Norwalk Station"
-    }
+    0.9890352454: {
+      stop_id: 80314,
+      stop_name: 'Norwalk Station',
+    },
   },
-  "804_0": {
-    "0.0027147209": {
-      "stop_id": 80401,
-      "stop_name": "Atlantic Station"
+  '804_0': {
+    0.0027147209: {
+      stop_id: 80401,
+      stop_name: 'Atlantic Station',
     },
-    "0.0157593": {
-      "stop_id": 80402,
-      "stop_name": "East LA Civic Center Station"
+    0.0157593: {
+      stop_id: 80402,
+      stop_name: 'East LA Civic Center Station',
     },
-    "0.02918225": {
-      "stop_id": 80403,
-      "stop_name": "Maravilla Station"
+    0.02918225: {
+      stop_id: 80403,
+      stop_name: 'Maravilla Station',
     },
-    "0.0772568126": {
-      "stop_id": 80404,
-      "stop_name": "Indiana Station"
+    0.0772568126: {
+      stop_id: 80404,
+      stop_name: 'Indiana Station',
     },
-    "0.1179075074": {
-      "stop_id": 80405,
-      "stop_name": "Soto Station"
+    0.1179075074: {
+      stop_id: 80405,
+      stop_name: 'Soto Station',
     },
-    "0.1379222771": {
-      "stop_id": 80406,
-      "stop_name": "Mariachi Plaza / Boyle Heights Station"
+    0.1379222771: {
+      stop_id: 80406,
+      stop_name: 'Mariachi Plaza / Boyle Heights Station',
     },
-    "0.1501288129": {
-      "stop_id": 80407,
-      "stop_name": "Pico / Aliso Station"
+    0.1501288129: {
+      stop_id: 80407,
+      stop_name: 'Pico / Aliso Station',
     },
-    "0.1752134735": {
-      "stop_id": 80408,
-      "stop_name": "Little Tokyo / Arts District Station"
+    0.1752134735: {
+      stop_id: 80408,
+      stop_name: 'Little Tokyo / Arts District Station',
     },
-    "0.1912098687": {
-      "stop_id": 80409,
-      "stop_name": "Union Station - Metro Gold Line"
+    0.1912098687: {
+      stop_id: 80409,
+      stop_name: 'Union Station - Metro Gold Line',
     },
-    "0.2092805943": {
-      "stop_id": 80410,
-      "stop_name": "Chinatown Station"
+    0.2092805943: {
+      stop_id: 80410,
+      stop_name: 'Chinatown Station',
     },
-    "0.2562688878": {
-      "stop_id": 80411,
-      "stop_name": "Lincoln Heights / Cypress Park Station"
+    0.2562688878: {
+      stop_id: 80411,
+      stop_name: 'Lincoln Heights / Cypress Park Station',
     },
-    "0.2748311558": {
-      "stop_id": 80412,
-      "stop_name": "Heritage Square / Arroyo Station"
+    0.2748311558: {
+      stop_id: 80412,
+      stop_name: 'Heritage Square / Arroyo Station',
     },
-    "0.3010717323": {
-      "stop_id": 80413,
-      "stop_name": "Southwest Museum Station"
+    0.3010717323: {
+      stop_id: 80413,
+      stop_name: 'Southwest Museum Station',
     },
-    "0.3411688412": {
-      "stop_id": 80414,
-      "stop_name": "Highland Park Station"
+    0.3411688412: {
+      stop_id: 80414,
+      stop_name: 'Highland Park Station',
     },
-    "0.4115318553": {
-      "stop_id": 80415,
-      "stop_name": "South Pasadena Station"
+    0.4115318553: {
+      stop_id: 80415,
+      stop_name: 'South Pasadena Station',
     },
-    "0.4556171146": {
-      "stop_id": 80416,
-      "stop_name": "Fillmore Station"
+    0.4556171146: {
+      stop_id: 80416,
+      stop_name: 'Fillmore Station',
     },
-    "0.4718575542": {
-      "stop_id": 80417,
-      "stop_name": "Del Mar Station"
+    0.4718575542: {
+      stop_id: 80417,
+      stop_name: 'Del Mar Station',
     },
-    "0.484621698": {
-      "stop_id": 80418,
-      "stop_name": "Memorial Park Station"
+    0.484621698: {
+      stop_id: 80418,
+      stop_name: 'Memorial Park Station',
     },
-    "0.5196040714": {
-      "stop_id": 80419,
-      "stop_name": "Lake Station"
+    0.5196040714: {
+      stop_id: 80419,
+      stop_name: 'Lake Station',
     },
-    "0.5526316698": {
-      "stop_id": 80420,
-      "stop_name": "Allen Station"
+    0.5526316698: {
+      stop_id: 80420,
+      stop_name: 'Allen Station',
     },
-    "0.6190413519": {
-      "stop_id": 80421,
-      "stop_name": "Sierra Madre Villa Station"
+    0.6190413519: {
+      stop_id: 80421,
+      stop_name: 'Sierra Madre Villa Station',
     },
-    "0.7228540419": {
-      "stop_id": 80422,
-      "stop_name": "Arcadia Station"
+    0.7228540419: {
+      stop_id: 80422,
+      stop_name: 'Arcadia Station',
     },
-    "0.7765539292": {
-      "stop_id": 80423,
-      "stop_name": "Monrovia Station"
+    0.7765539292: {
+      stop_id: 80423,
+      stop_name: 'Monrovia Station',
     },
-    "0.8460144389": {
-      "stop_id": 80424,
-      "stop_name": "Duarte / City of Hope Station"
+    0.8460144389: {
+      stop_id: 80424,
+      stop_name: 'Duarte / City of Hope Station',
     },
-    "0.915454343": {
-      "stop_id": 80425,
-      "stop_name": "Irwindale Station"
+    0.915454343: {
+      stop_id: 80425,
+      stop_name: 'Irwindale Station',
     },
-    "0.9673916852": {
-      "stop_id": 80426,
-      "stop_name": "Azusa Downtown Station"
+    0.9673916852: {
+      stop_id: 80426,
+      stop_name: 'Azusa Downtown Station',
     },
-    "0.9966254589": {
-      "stop_id": 80427,
-      "stop_name": "APU / Citrus College Station"
-    }
+    0.9966254589: {
+      stop_id: 80427,
+      stop_name: 'APU / Citrus College Station',
+    },
   },
-  "805_0": {
-    "0.013007261": {
-      "stop_id": 80216,
-      "stop_name": "Wilshire / Western Station"
+  '805_0': {
+    0.013007261: {
+      stop_id: 80216,
+      stop_name: 'Wilshire / Western Station',
     },
-    "0.0976357772": {
-      "stop_id": 80215,
-      "stop_name": "Wilshire / Normandie Station"
+    0.0976357772: {
+      stop_id: 80215,
+      stop_name: 'Wilshire / Normandie Station',
     },
-    "0.2357941731": {
-      "stop_id": 80209,
-      "stop_name": "Wilshire / Vermont Station"
+    0.2357941731: {
+      stop_id: 80209,
+      stop_name: 'Wilshire / Vermont Station',
     },
-    "0.431783208": {
-      "stop_id": 80210,
-      "stop_name": "Westlake / MacArthur Park Station"
+    0.431783208: {
+      stop_id: 80210,
+      stop_name: 'Westlake / MacArthur Park Station',
     },
-    "0.6411988556": {
-      "stop_id": 80211,
-      "stop_name": "7th Street / Metro Center Station - Metro Red & Purple Lines"
+    0.6411988556: {
+      stop_id: 80211,
+      stop_name: '7th Street / Metro Center Station - Metro Red & Purple Lines',
     },
-    "0.7426543648": {
-      "stop_id": 80212,
-      "stop_name": "Pershing Square Station"
+    0.7426543648: {
+      stop_id: 80212,
+      stop_name: 'Pershing Square Station',
     },
-    "0.8311442662": {
-      "stop_id": 80213,
-      "stop_name": "Civic Center / Grand Park Station"
+    0.8311442662: {
+      stop_id: 80213,
+      stop_name: 'Civic Center / Grand Park Station',
     },
-    "0.9855060742": {
-      "stop_id": 80214,
-      "stop_name": "Union Station - Metro Red & Purple Lines"
-    }
+    0.9855060742: {
+      stop_id: 80214,
+      stop_name: 'Union Station - Metro Red & Purple Lines',
+    },
   },
-  "806_0": {
-    "0.0015282507": {
-      "stop_id": 80139,
-      "stop_name": "Downtown Santa Monica Station"
+  '806_0': {
+    0.0015282507: {
+      stop_id: 80139,
+      stop_name: 'Downtown Santa Monica Station',
     },
-    "0.0571685976": {
-      "stop_id": 80138,
-      "stop_name": "17th Street / SMC Station"
+    0.0571685976: {
+      stop_id: 80138,
+      stop_name: '17th Street / SMC Station',
     },
-    "0.1049719213": {
-      "stop_id": 80137,
-      "stop_name": "26th Street / Bergamot Station"
+    0.1049719213: {
+      stop_id: 80137,
+      stop_name: '26th Street / Bergamot Station',
     },
-    "0.169623833": {
-      "stop_id": 80136,
-      "stop_name": "Expo / Bundy Station"
+    0.169623833: {
+      stop_id: 80136,
+      stop_name: 'Expo / Bundy Station',
     },
-    "0.2434752985": {
-      "stop_id": 80135,
-      "stop_name": "Expo / Sepulveda Station"
+    0.2434752985: {
+      stop_id: 80135,
+      stop_name: 'Expo / Sepulveda Station',
     },
-    "0.2813582919": {
-      "stop_id": 80134,
-      "stop_name": "Westwood / Rancho Park Station"
+    0.2813582919: {
+      stop_id: 80134,
+      stop_name: 'Westwood / Rancho Park Station',
     },
-    "0.3709216343": {
-      "stop_id": 80133,
-      "stop_name": "Palms Station"
+    0.3709216343: {
+      stop_id: 80133,
+      stop_name: 'Palms Station',
     },
-    "0.4304492622": {
-      "stop_id": 80132,
-      "stop_name": "Culver City Station"
+    0.4304492622: {
+      stop_id: 80132,
+      stop_name: 'Culver City Station',
     },
-    "0.4962151298": {
-      "stop_id": 80131,
-      "stop_name": "La Cienega / Jefferson Station"
+    0.4962151298: {
+      stop_id: 80131,
+      stop_name: 'La Cienega / Jefferson Station',
     },
-    "0.5623310182": {
-      "stop_id": 80130,
-      "stop_name": "Expo / La Brea / Ethel Bradley Station"
+    0.5623310182: {
+      stop_id: 80130,
+      stop_name: 'Expo / La Brea / Ethel Bradley Station',
     },
-    "0.5976553568": {
-      "stop_id": 80129,
-      "stop_name": "Farmdale Station"
+    0.5976553568: {
+      stop_id: 80129,
+      stop_name: 'Farmdale Station',
     },
-    "0.6407903461": {
-      "stop_id": 80128,
-      "stop_name": "Expo / Crenshaw Station"
+    0.6407903461: {
+      stop_id: 80128,
+      stop_name: 'Expo / Crenshaw Station',
     },
-    "0.7440394737": {
-      "stop_id": 80127,
-      "stop_name": "Expo / Western Station"
+    0.7440394737: {
+      stop_id: 80127,
+      stop_name: 'Expo / Western Station',
     },
-    "0.8114602088": {
-      "stop_id": 80126,
-      "stop_name": "Expo / Vermont Station"
+    0.8114602088: {
+      stop_id: 80126,
+      stop_name: 'Expo / Vermont Station',
     },
-    "0.8339960647": {
-      "stop_id": 80125,
-      "stop_name": "Expo Park / USC Station"
+    0.8339960647: {
+      stop_id: 80125,
+      stop_name: 'Expo Park / USC Station',
     },
-    "0.8713603565": {
-      "stop_id": 80124,
-      "stop_name": "Jefferson / USC Station"
+    0.8713603565: {
+      stop_id: 80124,
+      stop_name: 'Jefferson / USC Station',
     },
-    "0.9038420962": {
-      "stop_id": 80123,
-      "stop_name": "LATTC / Ortho Institute Station"
+    0.9038420962: {
+      stop_id: 80123,
+      stop_name: 'LATTC / Ortho Institute Station',
     },
-    "0.9575725551": {
-      "stop_id": 80121,
-      "stop_name": "Pico Station"
+    0.9575725551: {
+      stop_id: 80121,
+      stop_name: 'Pico Station',
     },
-    "0.9992335737": {
-      "stop_id": 80122,
-      "stop_name": "7th Street / Metro Center Station - Metro Blue & Expo Lines"
-    }
+    0.9992335737: {
+      stop_id: 80122,
+      stop_name: '7th Street / Metro Center Station - Metro Blue & Expo Lines',
+    },
   },
-  "801_1": {
-    "0.0005562556": {
-      "stop_id": 80122,
-      "stop_name": "7th Street / Metro Center Station - Metro Blue & Expo Lines"
+  '801_1': {
+    0.0005562556: {
+      stop_id: 80122,
+      stop_name: '7th Street / Metro Center Station - Metro Blue & Expo Lines',
     },
-    "0.0343268812": {
-      "stop_id": 80121,
-      "stop_name": "Pico Station"
+    0.0343268812: {
+      stop_id: 80121,
+      stop_name: 'Pico Station',
     },
-    "0.064950695": {
-      "stop_id": 80120,
-      "stop_name": "Grand / LATTC Station"
+    0.064950695: {
+      stop_id: 80120,
+      stop_name: 'Grand / LATTC Station',
     },
-    "0.1128107799": {
-      "stop_id": 80119,
-      "stop_name": "San Pedro Street Station"
+    0.1128107799: {
+      stop_id: 80119,
+      stop_name: 'San Pedro Street Station',
     },
-    "0.1592246249": {
-      "stop_id": 80118,
-      "stop_name": "Washington Station"
+    0.1592246249: {
+      stop_id: 80118,
+      stop_name: 'Washington Station',
     },
-    "0.2118580663": {
-      "stop_id": 80117,
-      "stop_name": "Vernon Station"
+    0.2118580663: {
+      stop_id: 80117,
+      stop_name: 'Vernon Station',
     },
-    "0.2564057004": {
-      "stop_id": 80116,
-      "stop_name": "Slauson Station"
+    0.2564057004: {
+      stop_id: 80116,
+      stop_name: 'Slauson Station',
     },
-    "0.3036523457": {
-      "stop_id": 80115,
-      "stop_name": "Florence Station"
+    0.3036523457: {
+      stop_id: 80115,
+      stop_name: 'Florence Station',
     },
-    "0.3480978625": {
-      "stop_id": 80114,
-      "stop_name": "Firestone Station"
+    0.3480978625: {
+      stop_id: 80114,
+      stop_name: 'Firestone Station',
     },
-    "0.4028056384": {
-      "stop_id": 80113,
-      "stop_name": "103rd Street / Watts Towers  Station"
+    0.4028056384: {
+      stop_id: 80113,
+      stop_name: '103rd Street / Watts Towers  Station',
     },
-    "0.4515488018": {
-      "stop_id": 80112,
-      "stop_name": "Willowbrook - Rosa Parks Station - Metro Blue Line"
+    0.4515488018: {
+      stop_id: 80112,
+      stop_name: 'Willowbrook - Rosa Parks Station - Metro Blue Line',
     },
-    "0.5574566169": {
-      "stop_id": 80111,
-      "stop_name": "Compton Station"
+    0.5574566169: {
+      stop_id: 80111,
+      stop_name: 'Compton Station',
     },
-    "0.6251635365": {
-      "stop_id": 80110,
-      "stop_name": "Artesia Station"
+    0.6251635365: {
+      stop_id: 80110,
+      stop_name: 'Artesia Station',
     },
-    "0.7199730776": {
-      "stop_id": 80109,
-      "stop_name": "Del Amo Station"
+    0.7199730776: {
+      stop_id: 80109,
+      stop_name: 'Del Amo Station',
     },
-    "0.8211789192": {
-      "stop_id": 80108,
-      "stop_name": "Wardlow Station"
+    0.8211789192: {
+      stop_id: 80108,
+      stop_name: 'Wardlow Station',
     },
-    "0.8659976599": {
-      "stop_id": 80107,
-      "stop_name": "Willow Street Station"
+    0.8659976599: {
+      stop_id: 80107,
+      stop_name: 'Willow Street Station',
     },
-    "0.9229145476": {
-      "stop_id": 80106,
-      "stop_name": "Pacific Coast Hwy Station"
+    0.9229145476: {
+      stop_id: 80106,
+      stop_name: 'Pacific Coast Hwy Station',
     },
-    "0.9457516388": {
-      "stop_id": 80105,
-      "stop_name": "Anaheim Street Station"
+    0.9457516388: {
+      stop_id: 80105,
+      stop_name: 'Anaheim Street Station',
     },
-    "0.971675132": {
-      "stop_id": 80154,
-      "stop_name": "5th Street Station"
+    0.971675132: {
+      stop_id: 80154,
+      stop_name: '5th Street Station',
     },
-    "0.9869657239": {
-      "stop_id": 80153,
-      "stop_name": "1st Street Station"
+    0.9869657239: {
+      stop_id: 80153,
+      stop_name: '1st Street Station',
     },
-    "0.9998309528": {
-      "stop_id": 80101,
-      "stop_name": "Downtown Long Beach Station"
-    }
+    0.9998309528: {
+      stop_id: 80101,
+      stop_name: 'Downtown Long Beach Station',
+    },
   },
-  "802_1": {
-    "0.0055136089": {
-      "stop_id": 80214,
-      "stop_name": "Union Station - Metro Red & Purple Lines"
+  '802_1': {
+    0.0055136089: {
+      stop_id: 80214,
+      stop_name: 'Union Station - Metro Red & Purple Lines',
     },
-    "0.0624251075": {
-      "stop_id": 80213,
-      "stop_name": "Civic Center / Grand Park Station"
+    0.0624251075: {
+      stop_id: 80213,
+      stop_name: 'Civic Center / Grand Park Station',
     },
-    "0.0946122407": {
-      "stop_id": 80212,
-      "stop_name": "Pershing Square Station"
+    0.0946122407: {
+      stop_id: 80212,
+      stop_name: 'Pershing Square Station',
     },
-    "0.1307973461": {
-      "stop_id": 80211,
-      "stop_name": "7th Street / Metro Center Station - Metro Red & Purple Lines"
+    0.1307973461: {
+      stop_id: 80211,
+      stop_name: '7th Street / Metro Center Station - Metro Red & Purple Lines',
     },
-    "0.2069404197": {
-      "stop_id": 80210,
-      "stop_name": "Westlake / MacArthur Park Station"
+    0.2069404197: {
+      stop_id: 80210,
+      stop_name: 'Westlake / MacArthur Park Station',
     },
-    "0.2784442835": {
-      "stop_id": 80209,
-      "stop_name": "Wilshire / Vermont Station"
+    0.2784442835: {
+      stop_id: 80209,
+      stop_name: 'Wilshire / Vermont Station',
     },
-    "0.3436315656": {
-      "stop_id": 80208,
-      "stop_name": "Vermont / Beverly Station"
+    0.3436315656: {
+      stop_id: 80208,
+      stop_name: 'Vermont / Beverly Station',
     },
-    "0.4000771567": {
-      "stop_id": 80207,
-      "stop_name": "Vermont / Santa Monica Station"
+    0.4000771567: {
+      stop_id: 80207,
+      stop_name: 'Vermont / Santa Monica Station',
     },
-    "0.432964394": {
-      "stop_id": 80206,
-      "stop_name": "Vermont / Sunset Station"
+    0.432964394: {
+      stop_id: 80206,
+      stop_name: 'Vermont / Sunset Station',
     },
-    "0.5138973436": {
-      "stop_id": 80205,
-      "stop_name": "Hollywood / Western Station"
+    0.5138973436: {
+      stop_id: 80205,
+      stop_name: 'Hollywood / Western Station',
     },
-    "0.5858607036": {
-      "stop_id": 80204,
-      "stop_name": "Hollywood / Vine Station"
+    0.5858607036: {
+      stop_id: 80204,
+      stop_name: 'Hollywood / Vine Station',
     },
-    "0.6422436831": {
-      "stop_id": 80203,
-      "stop_name": "Hollywood / Highland Station"
+    0.6422436831: {
+      stop_id: 80203,
+      stop_name: 'Hollywood / Highland Station',
     },
-    "0.8511230406": {
-      "stop_id": 80202,
-      "stop_name": "Universal / Studio City Station"
+    0.8511230406: {
+      stop_id: 80202,
+      stop_name: 'Universal / Studio City Station',
     },
-    "0.9886028758": {
-      "stop_id": 80201,
-      "stop_name": "North Hollywood Station"
-    }
+    0.9886028758: {
+      stop_id: 80201,
+      stop_name: 'North Hollywood Station',
+    },
   },
-  "803_1": {
-    "0.0109745211": {
-      "stop_id": 80314,
-      "stop_name": "Norwalk Station"
+  '803_1': {
+    0.0109745211: {
+      stop_id: 80314,
+      stop_name: 'Norwalk Station',
     },
-    "0.1177044657": {
-      "stop_id": 80313,
-      "stop_name": "Lakewood Blvd Station"
+    0.1177044657: {
+      stop_id: 80313,
+      stop_name: 'Lakewood Blvd Station',
     },
-    "0.3317636497": {
-      "stop_id": 80312,
-      "stop_name": "Long Beach Blvd Station"
+    0.3317636497: {
+      stop_id: 80312,
+      stop_name: 'Long Beach Blvd Station',
     },
-    "0.4185852512": {
-      "stop_id": 80311,
-      "stop_name": "Willowbrook - Rosa Parks Station - Metro Green Line"
+    0.4185852512: {
+      stop_id: 80311,
+      stop_name: 'Willowbrook - Rosa Parks Station - Metro Green Line',
     },
-    "0.4996082186": {
-      "stop_id": 80310,
-      "stop_name": "Avalon Station"
+    0.4996082186: {
+      stop_id: 80310,
+      stop_name: 'Avalon Station',
     },
-    "0.5471516967": {
-      "stop_id": 80309,
-      "stop_name": "Harbor Freeway Station"
+    0.5471516967: {
+      stop_id: 80309,
+      stop_name: 'Harbor Freeway Station',
     },
-    "0.5787573497": {
-      "stop_id": 80308,
-      "stop_name": "Vermont / Athens Station"
+    0.5787573497: {
+      stop_id: 80308,
+      stop_name: 'Vermont / Athens Station',
     },
-    "0.6832199992": {
-      "stop_id": 80307,
-      "stop_name": "Crenshaw Station"
+    0.6832199992: {
+      stop_id: 80307,
+      stop_name: 'Crenshaw Station',
     },
-    "0.764273912": {
-      "stop_id": 80306,
-      "stop_name": "Hawthorne / Lennox Station"
+    0.764273912: {
+      stop_id: 80306,
+      stop_name: 'Hawthorne / Lennox Station',
     },
-    "0.8417961485": {
-      "stop_id": 80305,
-      "stop_name": "Aviation / LAX Station"
+    0.8417961485: {
+      stop_id: 80305,
+      stop_name: 'Aviation / LAX Station',
     },
-    "0.8864667672": {
-      "stop_id": 80304,
-      "stop_name": "Mariposa Station"
+    0.8864667672: {
+      stop_id: 80304,
+      stop_name: 'Mariposa Station',
     },
-    "0.9090127495": {
-      "stop_id": 80303,
-      "stop_name": "El Segundo Station"
+    0.9090127495: {
+      stop_id: 80303,
+      stop_name: 'El Segundo Station',
     },
-    "0.9450493338": {
-      "stop_id": 80302,
-      "stop_name": "Douglas Station"
+    0.9450493338: {
+      stop_id: 80302,
+      stop_name: 'Douglas Station',
     },
-    "0.9971642913": {
-      "stop_id": 80301,
-      "stop_name": "Redondo Beach Station"
-    }
+    0.9971642913: {
+      stop_id: 80301,
+      stop_name: 'Redondo Beach Station',
+    },
   },
-  "804_1": {
-    "0.0033715085": {
-      "stop_id": 80427,
-      "stop_name": "APU / Citrus College Station"
+  '804_1': {
+    0.0033715085: {
+      stop_id: 80427,
+      stop_name: 'APU / Citrus College Station',
     },
-    "0.0325944627": {
-      "stop_id": 80426,
-      "stop_name": "Azusa Downtown Station"
+    0.0325944627: {
+      stop_id: 80426,
+      stop_name: 'Azusa Downtown Station',
     },
-    "0.0844860661": {
-      "stop_id": 80425,
-      "stop_name": "Irwindale Station"
+    0.0844860661: {
+      stop_id: 80425,
+      stop_name: 'Irwindale Station',
     },
-    "0.1538827873": {
-      "stop_id": 80424,
-      "stop_name": "Duarte / City of Hope Station"
+    0.1538827873: {
+      stop_id: 80424,
+      stop_name: 'Duarte / City of Hope Station',
     },
-    "0.2232830119": {
-      "stop_id": 80423,
-      "stop_name": "Monrovia Station"
+    0.2232830119: {
+      stop_id: 80423,
+      stop_name: 'Monrovia Station',
     },
-    "0.2769263796": {
-      "stop_id": 80422,
-      "stop_name": "Arcadia Station"
+    0.2769263796: {
+      stop_id: 80422,
+      stop_name: 'Arcadia Station',
     },
-    "0.3807289833": {
-      "stop_id": 80421,
-      "stop_name": "Sierra Madre Villa Station"
+    0.3807289833: {
+      stop_id: 80421,
+      stop_name: 'Sierra Madre Villa Station',
     },
-    "0.4470857419": {
-      "stop_id": 80420,
-      "stop_name": "Allen Station"
+    0.4470857419: {
+      stop_id: 80420,
+      stop_name: 'Allen Station',
     },
-    "0.4800919281": {
-      "stop_id": 80419,
-      "stop_name": "Lake Station"
+    0.4800919281: {
+      stop_id: 80419,
+      stop_name: 'Lake Station',
     },
-    "0.515137293": {
-      "stop_id": 80418,
-      "stop_name": "Memorial Park Station"
+    0.515137293: {
+      stop_id: 80418,
+      stop_name: 'Memorial Park Station',
     },
-    "0.5279527714": {
-      "stop_id": 80417,
-      "stop_name": "Del Mar Station"
+    0.5279527714: {
+      stop_id: 80417,
+      stop_name: 'Del Mar Station',
     },
-    "0.5441878445": {
-      "stop_id": 80416,
-      "stop_name": "Fillmore Station"
+    0.5441878445: {
+      stop_id: 80416,
+      stop_name: 'Fillmore Station',
     },
-    "0.5881884133": {
-      "stop_id": 80415,
-      "stop_name": "South Pasadena Station"
+    0.5881884133: {
+      stop_id: 80415,
+      stop_name: 'South Pasadena Station',
     },
-    "0.6585101464": {
-      "stop_id": 80414,
-      "stop_name": "Highland Park Station"
+    0.6585101464: {
+      stop_id: 80414,
+      stop_name: 'Highland Park Station',
     },
-    "0.698555377": {
-      "stop_id": 80413,
-      "stop_name": "Southwest Museum Station"
+    0.698555377: {
+      stop_id: 80413,
+      stop_name: 'Southwest Museum Station',
     },
-    "0.724807738": {
-      "stop_id": 80412,
-      "stop_name": "Heritage Square / Arroyo Station"
+    0.724807738: {
+      stop_id: 80412,
+      stop_name: 'Heritage Square / Arroyo Station',
     },
-    "0.7433438626": {
-      "stop_id": 80411,
-      "stop_name": "Lincoln Heights / Cypress Park Station"
+    0.7433438626: {
+      stop_id: 80411,
+      stop_name: 'Lincoln Heights / Cypress Park Station',
     },
-    "0.7903689072": {
-      "stop_id": 80410,
-      "stop_name": "Chinatown Station"
+    0.7903689072: {
+      stop_id: 80410,
+      stop_name: 'Chinatown Station',
     },
-    "0.808575234": {
-      "stop_id": 80409,
-      "stop_name": "Union Station - Metro Gold Line"
+    0.808575234: {
+      stop_id: 80409,
+      stop_name: 'Union Station - Metro Gold Line',
     },
-    "0.8245798952": {
-      "stop_id": 80408,
-      "stop_name": "Little Tokyo / Arts District Station"
+    0.8245798952: {
+      stop_id: 80408,
+      stop_name: 'Little Tokyo / Arts District Station',
     },
-    "0.8498702817": {
-      "stop_id": 80407,
-      "stop_name": "Pico / Aliso Station"
+    0.8498702817: {
+      stop_id: 80407,
+      stop_name: 'Pico / Aliso Station',
     },
-    "0.8620696597": {
-      "stop_id": 80406,
-      "stop_name": "Mariachi Plaza / Boyle Heights Station"
+    0.8620696597: {
+      stop_id: 80406,
+      stop_name: 'Mariachi Plaza / Boyle Heights Station',
     },
-    "0.8820415857": {
-      "stop_id": 80405,
-      "stop_name": "Soto Station"
+    0.8820415857: {
+      stop_id: 80405,
+      stop_name: 'Soto Station',
     },
-    "0.9225625884": {
-      "stop_id": 80404,
-      "stop_name": "Indiana Station"
+    0.9225625884: {
+      stop_id: 80404,
+      stop_name: 'Indiana Station',
     },
-    "0.9708352019": {
-      "stop_id": 80403,
-      "stop_name": "Maravilla Station"
+    0.9708352019: {
+      stop_id: 80403,
+      stop_name: 'Maravilla Station',
     },
-    "0.9842507658": {
-      "stop_id": 80402,
-      "stop_name": "East LA Civic Center Station"
+    0.9842507658: {
+      stop_id: 80402,
+      stop_name: 'East LA Civic Center Station',
     },
-    "0.997285367": {
-      "stop_id": 80401,
-      "stop_name": "Atlantic Station"
-    }
+    0.997285367: {
+      stop_id: 80401,
+      stop_name: 'Atlantic Station',
+    },
   },
-  "805_1": {
-    "0.0151429796": {
-      "stop_id": 80214,
-      "stop_name": "Union Station - Metro Red & Purple Lines"
+  '805_1': {
+    0.0151429796: {
+      stop_id: 80214,
+      stop_name: 'Union Station - Metro Red & Purple Lines',
     },
-    "0.1714488907": {
-      "stop_id": 80213,
-      "stop_name": "Civic Center / Grand Park Station"
+    0.1714488907: {
+      stop_id: 80213,
+      stop_name: 'Civic Center / Grand Park Station',
     },
-    "0.2598499926": {
-      "stop_id": 80212,
-      "stop_name": "Pershing Square Station"
+    0.2598499926: {
+      stop_id: 80212,
+      stop_name: 'Pershing Square Station',
     },
-    "0.3592314182": {
-      "stop_id": 80211,
-      "stop_name": "7th Street / Metro Center Station - Metro Red & Purple Lines"
+    0.3592314182: {
+      stop_id: 80211,
+      stop_name: '7th Street / Metro Center Station - Metro Red & Purple Lines',
     },
-    "0.5683563366": {
-      "stop_id": 80210,
-      "stop_name": "Westlake / MacArthur Park Station"
+    0.5683563366: {
+      stop_id: 80210,
+      stop_name: 'Westlake / MacArthur Park Station',
     },
-    "0.764739789": {
-      "stop_id": 80209,
-      "stop_name": "Wilshire / Vermont Station"
+    0.764739789: {
+      stop_id: 80209,
+      stop_name: 'Wilshire / Vermont Station',
     },
-    "0.9024688421": {
-      "stop_id": 80215,
-      "stop_name": "Wilshire / Normandie Station"
+    0.9024688421: {
+      stop_id: 80215,
+      stop_name: 'Wilshire / Normandie Station',
     },
-    "0.987003723": {
-      "stop_id": 80216,
-      "stop_name": "Wilshire / Western Station"
-    }
+    0.987003723: {
+      stop_id: 80216,
+      stop_name: 'Wilshire / Western Station',
+    },
   },
-  "806_1": {
-    "0.0005580173": {
-      "stop_id": 80122,
-      "stop_name": "7th Street / Metro Center Station - Metro Blue & Expo Lines"
+  '806_1': {
+    0.0005580173: {
+      stop_id: 80122,
+      stop_name: '7th Street / Metro Center Station - Metro Blue & Expo Lines',
     },
-    "0.0422353832": {
-      "stop_id": 80121,
-      "stop_name": "Pico Station"
+    0.0422353832: {
+      stop_id: 80121,
+      stop_name: 'Pico Station',
     },
-    "0.0960152771": {
-      "stop_id": 80123,
-      "stop_name": "LATTC / Ortho Institute Station"
+    0.0960152771: {
+      stop_id: 80123,
+      stop_name: 'LATTC / Ortho Institute Station',
     },
-    "0.1284864322": {
-      "stop_id": 80124,
-      "stop_name": "Jefferson / USC Station"
+    0.1284864322: {
+      stop_id: 80124,
+      stop_name: 'Jefferson / USC Station',
     },
-    "0.1656232148": {
-      "stop_id": 80125,
-      "stop_name": "Expo Park / USC Station"
+    0.1656232148: {
+      stop_id: 80125,
+      stop_name: 'Expo Park / USC Station',
     },
-    "0.1881598179": {
-      "stop_id": 80126,
-      "stop_name": "Expo / Vermont Station"
+    0.1881598179: {
+      stop_id: 80126,
+      stop_name: 'Expo / Vermont Station',
     },
-    "0.255589438": {
-      "stop_id": 80127,
-      "stop_name": "Expo / Western Station"
+    0.255589438: {
+      stop_id: 80127,
+      stop_name: 'Expo / Western Station',
     },
-    "0.3588246824": {
-      "stop_id": 80128,
-      "stop_name": "Expo / Crenshaw Station"
+    0.3588246824: {
+      stop_id: 80128,
+      stop_name: 'Expo / Crenshaw Station',
     },
-    "0.4019814654": {
-      "stop_id": 80129,
-      "stop_name": "Farmdale Station"
+    0.4019814654: {
+      stop_id: 80129,
+      stop_name: 'Farmdale Station',
     },
-    "0.4373113354": {
-      "stop_id": 80130,
-      "stop_name": "Expo / La Brea / Ethel Bradley Station"
+    0.4373113354: {
+      stop_id: 80130,
+      stop_name: 'Expo / La Brea / Ethel Bradley Station',
     },
-    "0.5034348928": {
-      "stop_id": 80131,
-      "stop_name": "La Cienega / Jefferson Station"
+    0.5034348928: {
+      stop_id: 80131,
+      stop_name: 'La Cienega / Jefferson Station',
     },
-    "0.5691837537": {
-      "stop_id": 80132,
-      "stop_name": "Culver City Station"
+    0.5691837537: {
+      stop_id: 80132,
+      stop_name: 'Culver City Station',
     },
-    "0.6287160228": {
-      "stop_id": 80133,
-      "stop_name": "Palms Station"
+    0.6287160228: {
+      stop_id: 80133,
+      stop_name: 'Palms Station',
     },
-    "0.7183446777": {
-      "stop_id": 80134,
-      "stop_name": "Westwood / Rancho Park Station"
+    0.7183446777: {
+      stop_id: 80134,
+      stop_name: 'Westwood / Rancho Park Station',
     },
-    "0.7562349647": {
-      "stop_id": 80135,
-      "stop_name": "Expo / Sepulveda Station"
+    0.7562349647: {
+      stop_id: 80135,
+      stop_name: 'Expo / Sepulveda Station',
     },
-    "0.8301123786": {
-      "stop_id": 80136,
-      "stop_name": "Expo / Bundy Station"
+    0.8301123786: {
+      stop_id: 80136,
+      stop_name: 'Expo / Bundy Station',
     },
-    "0.8947935559": {
-      "stop_id": 80137,
-      "stop_name": "26th Street / Bergamot Station"
+    0.8947935559: {
+      stop_id: 80137,
+      stop_name: '26th Street / Bergamot Station',
     },
-    "0.9426962554": {
-      "stop_id": 80138,
-      "stop_name": "17th Street / SMC Station"
+    0.9426962554: {
+      stop_id: 80138,
+      stop_name: '17th Street / SMC Station',
     },
-    "0.9984136235": {
-      "stop_id": 80139,
-      "stop_name": "Downtown Santa Monica Station"
-    }
-  }
-}
+    0.9984136235: {
+      stop_id: 80139,
+      stop_name: 'Downtown Santa Monica Station',
+    },
+  },
+};

--- a/helpers/PrepareData.js
+++ b/helpers/PrepareData.js
@@ -1,20 +1,18 @@
 import DataFrame from 'dataframe-js';
-import stopPositions from './StopPositions.js';
 import moment from 'moment-timezone';
+import stopPositions from './StopPositions.js';
 
 
 const collectObservedTrip = (trip) => {
   const theTrip = trip.group
     .toCollection()
-    .map(row => {
-      return (
-        {
-          x: row.relative_position, 
-          y: new Date(row.datetime).getTime(),
-          name: null
-        }
-      )
-    });
+    .map(row => (
+      {
+        x: row.relative_position,
+        y: new Date(row.datetime).getTime(),
+        name: null,
+      }
+    ));
   return { data: theTrip, color: '#f00', enableMouseTracking: false };
 };
 
@@ -36,8 +34,8 @@ const prepareObservations = (url, updateFunction) => {
 };
 
 const getStations = (line) => {
-  DataFrame.fromCSV(``)
-}
+  DataFrame.fromCSV('');
+};
 
 const prepareSchedule = (url, line, updateFunction) => {
   DataFrame.fromCSV(url).then((df) => {
@@ -56,33 +54,29 @@ const prepareSchedule = (url, line, updateFunction) => {
     const collectScheduleTrip0 = (trip) => {
       const theTrip = trip.group
         .toCollection()
-        .map(row => {
-          return (
-            {
-              // This conditional exists because of an upstream bug,
-              // sometimes stops on other lines end up in the CSV
-              x: stops0[row.stop_id] ? stops0[row.stop_id]["relative_position"] : 0,
-              y: new Date(row.datetime).getTime(),
-              name: stops0[row.stop_id] ? stops0[row.stop_id]["stop_name"] : "Error"
-            }
-          )
-        });
+        .map(row => (
+          {
+            // This conditional exists because of an upstream bug,
+            // sometimes stops on other lines end up in the CSV
+            x: stops0[row.stop_id] ? stops0[row.stop_id].relative_position : 0,
+            y: new Date(row.datetime).getTime(),
+            name: stops0[row.stop_id] ? stops0[row.stop_id].stop_name : 'Error',
+          }
+        ));
       return { data: theTrip, color: '#aaaaaa' };
     };
     const collectScheduleTrip1 = (trip) => {
       const theTrip = trip.group
         .toCollection()
-        .map(row => {
-          return (
-            {
-              // This conditional exists because of an upstream bug,
-              // sometimes stops on other lines end up in the CSV
-              x: stops1[row.stop_id] ? stops1[row.stop_id]["relative_position"] : 0,
-              y: new Date(row.datetime).getTime(),
-              name: stops1[row.stop_id] ? stops1[row.stop_id]["stop_name"] : "Error"
-            }
-          )
-        });
+        .map(row => (
+          {
+            // This conditional exists because of an upstream bug,
+            // sometimes stops on other lines end up in the CSV
+            x: stops1[row.stop_id] ? stops1[row.stop_id].relative_position : 0,
+            y: new Date(row.datetime).getTime(),
+            name: stops1[row.stop_id] ? stops1[row.stop_id].stop_name : 'Error',
+          }
+        ));
       return { data: theTrip, color: '#aaaaaa' };
     };
 

--- a/helpers/StopPositions.js
+++ b/helpers/StopPositions.js
@@ -1,847 +1,846 @@
 export default {
-  "801_0": {
-    "80101": {
-      "relative_position": 0,
-      "stop_name": "Downtown Long Beach Station"
+  '801_0': {
+    80101: {
+      relative_position: 0,
+      stop_name: 'Downtown Long Beach Station',
     },
-    "80102": {
-      "relative_position": 0.015038366,
-      "stop_name": "Pacific Ave Station"
+    80102: {
+      relative_position: 0.015038366,
+      stop_name: 'Pacific Ave Station',
     },
-    "80105": {
-      "relative_position": 0.0568415579,
-      "stop_name": "Anaheim Street Station"
+    80105: {
+      relative_position: 0.0568415579,
+      stop_name: 'Anaheim Street Station',
     },
-    "80106": {
-      "relative_position": 0.0790934445,
-      "stop_name": "Pacific Coast Hwy Station"
+    80106: {
+      relative_position: 0.0790934445,
+      stop_name: 'Pacific Coast Hwy Station',
     },
-    "80107": {
-      "relative_position": 0.1346358563,
-      "stop_name": "Willow Street Station"
+    80107: {
+      relative_position: 0.1346358563,
+      stop_name: 'Willow Street Station',
     },
-    "80108": {
-      "relative_position": 0.178332583,
-      "stop_name": "Wardlow Station"
+    80108: {
+      relative_position: 0.178332583,
+      stop_name: 'Wardlow Station',
     },
-    "80109": {
-      "relative_position": 0.2769232974,
-      "stop_name": "Del Amo Station"
+    80109: {
+      relative_position: 0.2769232974,
+      stop_name: 'Del Amo Station',
     },
-    "80110": {
-      "relative_position": 0.3692947148,
-      "stop_name": "Artesia Station"
+    80110: {
+      relative_position: 0.3692947148,
+      stop_name: 'Artesia Station',
     },
-    "80111": {
-      "relative_position": 0.4352200647,
-      "stop_name": "Compton Station"
+    80111: {
+      relative_position: 0.4352200647,
+      stop_name: 'Compton Station',
     },
-    "80112": {
-      "relative_position": 0.5600720018,
-      "stop_name": "Willowbrook - Rosa Parks Station - Metro Blue Line"
+    80112: {
+      relative_position: 0.5600720018,
+      stop_name: 'Willowbrook - Rosa Parks Station - Metro Blue Line',
     },
-    "80113": {
-      "relative_position": 0.6074913717,
-      "stop_name": "103rd Street / Watts Towers  Station"
+    80113: {
+      relative_position: 0.6074913717,
+      stop_name: '103rd Street / Watts Towers  Station',
     },
-    "80114": {
-      "relative_position": 0.6607977235,
-      "stop_name": "Firestone Station"
+    80114: {
+      relative_position: 0.6607977235,
+      stop_name: 'Firestone Station',
     },
-    "80115": {
-      "relative_position": 0.704102429,
-      "stop_name": "Florence Station"
+    80115: {
+      relative_position: 0.704102429,
+      stop_name: 'Florence Station',
     },
-    "80116": {
-      "relative_position": 0.7501449099,
-      "stop_name": "Slauson Station"
+    80116: {
+      relative_position: 0.7501449099,
+      stop_name: 'Slauson Station',
     },
-    "80117": {
-      "relative_position": 0.7935442741,
-      "stop_name": "Vernon Station"
+    80117: {
+      relative_position: 0.7935442741,
+      stop_name: 'Vernon Station',
     },
-    "80118": {
-      "relative_position": 0.8448266783,
-      "stop_name": "Washington Station"
+    80118: {
+      relative_position: 0.8448266783,
+      stop_name: 'Washington Station',
     },
-    "80119": {
-      "relative_position": 0.8903047134,
-      "stop_name": "San Pedro Street Station"
+    80119: {
+      relative_position: 0.8903047134,
+      stop_name: 'San Pedro Street Station',
     },
-    "80120": {
-      "relative_position": 0.9369389647,
-      "stop_name": "Grand / LATTC Station"
+    80120: {
+      relative_position: 0.9369389647,
+      stop_name: 'Grand / LATTC Station',
     },
-    "80121": {
-      "relative_position": 0.9664983021,
-      "stop_name": "Pico Station"
+    80121: {
+      relative_position: 0.9664983021,
+      stop_name: 'Pico Station',
     },
-    "80122": {
-      "relative_position": 0.999394812,
-      "stop_name": "7th Street / Metro Center Station - Metro Blue & Expo Lines"
-    }
+    80122: {
+      relative_position: 0.999394812,
+      stop_name: '7th Street / Metro Center Station - Metro Blue & Expo Lines',
+    },
   },
-  "802_0": {
-    "80201": {
-      "relative_position": 0.011481427,
-      "stop_name": "North Hollywood Station"
+  '802_0': {
+    80201: {
+      relative_position: 0.011481427,
+      stop_name: 'North Hollywood Station',
     },
-    "80202": {
-      "relative_position": 0.1486530455,
-      "stop_name": "Universal / Studio City Station"
+    80202: {
+      relative_position: 0.1486530455,
+      stop_name: 'Universal / Studio City Station',
     },
-    "80203": {
-      "relative_position": 0.3588269453,
-      "stop_name": "Hollywood / Highland Station"
+    80203: {
+      relative_position: 0.3588269453,
+      stop_name: 'Hollywood / Highland Station',
     },
-    "80204": {
-      "relative_position": 0.4152410658,
-      "stop_name": "Hollywood / Vine Station"
+    80204: {
+      relative_position: 0.4152410658,
+      stop_name: 'Hollywood / Vine Station',
     },
-    "80205": {
-      "relative_position": 0.4872420162,
-      "stop_name": "Hollywood / Western Station"
+    80205: {
+      relative_position: 0.4872420162,
+      stop_name: 'Hollywood / Western Station',
     },
-    "80206": {
-      "relative_position": 0.5674176048,
-      "stop_name": "Vermont / Sunset Station"
+    80206: {
+      relative_position: 0.5674176048,
+      stop_name: 'Vermont / Sunset Station',
     },
-    "80207": {
-      "relative_position": 0.6003228502,
-      "stop_name": "Vermont / Santa Monica Station"
+    80207: {
+      relative_position: 0.6003228502,
+      stop_name: 'Vermont / Santa Monica Station',
     },
-    "80208": {
-      "relative_position": 0.6567993483,
-      "stop_name": "Vermont / Beverly Station"
+    80208: {
+      relative_position: 0.6567993483,
+      stop_name: 'Vermont / Beverly Station',
     },
-    "80209": {
-      "relative_position": 0.7219057515,
-      "stop_name": "Wilshire / Vermont Station"
+    80209: {
+      relative_position: 0.7219057515,
+      stop_name: 'Wilshire / Vermont Station',
     },
-    "80210": {
-      "relative_position": 0.7932260967,
-      "stop_name": "Westlake / MacArthur Park Station"
+    80210: {
+      relative_position: 0.7932260967,
+      stop_name: 'Westlake / MacArthur Park Station',
     },
-    "80211": {
-      "relative_position": 0.8694323818,
-      "stop_name": "7th Street / Metro Center Station - Metro Red & Purple Lines"
+    80211: {
+      relative_position: 0.8694323818,
+      stop_name: '7th Street / Metro Center Station - Metro Red & Purple Lines',
     },
-    "80212": {
-      "relative_position": 0.9063520082,
-      "stop_name": "Pershing Square Station"
+    80212: {
+      relative_position: 0.9063520082,
+      stop_name: 'Pershing Square Station',
     },
-    "80213": {
-      "relative_position": 0.9385534541,
-      "stop_name": "Civic Center / Grand Park Station"
+    80213: {
+      relative_position: 0.9385534541,
+      stop_name: 'Civic Center / Grand Park Station',
     },
-    "80214": {
-      "relative_position": 0.9947256652,
-      "stop_name": "Union Station - Metro Red & Purple Lines"
-    }
+    80214: {
+      relative_position: 0.9947256652,
+      stop_name: 'Union Station - Metro Red & Purple Lines',
+    },
   },
-  "803_0": {
-    "80301": {
-      "relative_position": 0.0028660968,
-      "stop_name": "Redondo Beach Station"
+  '803_0': {
+    80301: {
+      relative_position: 0.0028660968,
+      stop_name: 'Redondo Beach Station',
     },
-    "80302": {
-      "relative_position": 0.0550048966,
-      "stop_name": "Douglas Station"
+    80302: {
+      relative_position: 0.0550048966,
+      stop_name: 'Douglas Station',
     },
-    "80303": {
-      "relative_position": 0.0910830652,
-      "stop_name": "El Segundo Station"
+    80303: {
+      relative_position: 0.0910830652,
+      stop_name: 'El Segundo Station',
     },
-    "80304": {
-      "relative_position": 0.1134165058,
-      "stop_name": "Mariposa Station"
+    80304: {
+      relative_position: 0.1134165058,
+      stop_name: 'Mariposa Station',
     },
-    "80305": {
-      "relative_position": 0.1578694227,
-      "stop_name": "Aviation / LAX Station"
+    80305: {
+      relative_position: 0.1578694227,
+      stop_name: 'Aviation / LAX Station',
     },
-    "80306": {
-      "relative_position": 0.2353916104,
-      "stop_name": "Hawthorne / Lennox Station"
+    80306: {
+      relative_position: 0.2353916104,
+      stop_name: 'Hawthorne / Lennox Station',
     },
-    "80307": {
-      "relative_position": 0.3164939375,
-      "stop_name": "Crenshaw Station"
+    80307: {
+      relative_position: 0.3164939375,
+      stop_name: 'Crenshaw Station',
     },
-    "80308": {
-      "relative_position": 0.4209828433,
-      "stop_name": "Vermont / Athens Station"
+    80308: {
+      relative_position: 0.4209828433,
+      stop_name: 'Vermont / Athens Station',
     },
-    "80309": {
-      "relative_position": 0.4526033946,
-      "stop_name": "Harbor Freeway Station"
+    80309: {
+      relative_position: 0.4526033946,
+      stop_name: 'Harbor Freeway Station',
     },
-    "80310": {
-      "relative_position": 0.5001332559,
-      "stop_name": "Avalon Station"
+    80310: {
+      relative_position: 0.5001332559,
+      stop_name: 'Avalon Station',
     },
-    "80311": {
-      "relative_position": 0.5811743311,
-      "stop_name": "Willowbrook - Rosa Parks Station - Metro Green Line"
+    80311: {
+      relative_position: 0.5811743311,
+      stop_name: 'Willowbrook - Rosa Parks Station - Metro Green Line',
     },
-    "80312": {
-      "relative_position": 0.6680095776,
-      "stop_name": "Long Beach Blvd Station"
+    80312: {
+      relative_position: 0.6680095776,
+      stop_name: 'Long Beach Blvd Station',
     },
-    "80313": {
-      "relative_position": 0.8822319642,
-      "stop_name": "Lakewood Blvd Station"
+    80313: {
+      relative_position: 0.8822319642,
+      stop_name: 'Lakewood Blvd Station',
     },
-    "80314": {
-      "relative_position": 0.9890352454,
-      "stop_name": "Norwalk Station"
-    }
+    80314: {
+      relative_position: 0.9890352454,
+      stop_name: 'Norwalk Station',
+    },
   },
-  "804_0": {
-    "80401": {
-      "relative_position": 0.0027147209,
-      "stop_name": "Atlantic Station"
+  '804_0': {
+    80401: {
+      relative_position: 0.0027147209,
+      stop_name: 'Atlantic Station',
     },
-    "80402": {
-      "relative_position": 0.0157593,
-      "stop_name": "East LA Civic Center Station"
+    80402: {
+      relative_position: 0.0157593,
+      stop_name: 'East LA Civic Center Station',
     },
-    "80403": {
-      "relative_position": 0.02918225,
-      "stop_name": "Maravilla Station"
+    80403: {
+      relative_position: 0.02918225,
+      stop_name: 'Maravilla Station',
     },
-    "80404": {
-      "relative_position": 0.0772568126,
-      "stop_name": "Indiana Station"
+    80404: {
+      relative_position: 0.0772568126,
+      stop_name: 'Indiana Station',
     },
-    "80405": {
-      "relative_position": 0.1179075074,
-      "stop_name": "Soto Station"
+    80405: {
+      relative_position: 0.1179075074,
+      stop_name: 'Soto Station',
     },
-    "80406": {
-      "relative_position": 0.1379222771,
-      "stop_name": "Mariachi Plaza / Boyle Heights Station"
+    80406: {
+      relative_position: 0.1379222771,
+      stop_name: 'Mariachi Plaza / Boyle Heights Station',
     },
-    "80407": {
-      "relative_position": 0.1501288129,
-      "stop_name": "Pico / Aliso Station"
+    80407: {
+      relative_position: 0.1501288129,
+      stop_name: 'Pico / Aliso Station',
     },
-    "80408": {
-      "relative_position": 0.1752134735,
-      "stop_name": "Little Tokyo / Arts District Station"
+    80408: {
+      relative_position: 0.1752134735,
+      stop_name: 'Little Tokyo / Arts District Station',
     },
-    "80409": {
-      "relative_position": 0.1912098687,
-      "stop_name": "Union Station - Metro Gold Line"
+    80409: {
+      relative_position: 0.1912098687,
+      stop_name: 'Union Station - Metro Gold Line',
     },
-    "80410": {
-      "relative_position": 0.2092805943,
-      "stop_name": "Chinatown Station"
+    80410: {
+      relative_position: 0.2092805943,
+      stop_name: 'Chinatown Station',
     },
-    "80411": {
-      "relative_position": 0.2562688878,
-      "stop_name": "Lincoln Heights / Cypress Park Station"
+    80411: {
+      relative_position: 0.2562688878,
+      stop_name: 'Lincoln Heights / Cypress Park Station',
     },
-    "80412": {
-      "relative_position": 0.2748311558,
-      "stop_name": "Heritage Square / Arroyo Station"
+    80412: {
+      relative_position: 0.2748311558,
+      stop_name: 'Heritage Square / Arroyo Station',
     },
-    "80413": {
-      "relative_position": 0.3010717323,
-      "stop_name": "Southwest Museum Station"
+    80413: {
+      relative_position: 0.3010717323,
+      stop_name: 'Southwest Museum Station',
     },
-    "80414": {
-      "relative_position": 0.3411688412,
-      "stop_name": "Highland Park Station"
+    80414: {
+      relative_position: 0.3411688412,
+      stop_name: 'Highland Park Station',
     },
-    "80415": {
-      "relative_position": 0.4115318553,
-      "stop_name": "South Pasadena Station"
+    80415: {
+      relative_position: 0.4115318553,
+      stop_name: 'South Pasadena Station',
     },
-    "80416": {
-      "relative_position": 0.4556171146,
-      "stop_name": "Fillmore Station"
+    80416: {
+      relative_position: 0.4556171146,
+      stop_name: 'Fillmore Station',
     },
-    "80417": {
-      "relative_position": 0.4718575542,
-      "stop_name": "Del Mar Station"
+    80417: {
+      relative_position: 0.4718575542,
+      stop_name: 'Del Mar Station',
     },
-    "80418": {
-      "relative_position": 0.484621698,
-      "stop_name": "Memorial Park Station"
+    80418: {
+      relative_position: 0.484621698,
+      stop_name: 'Memorial Park Station',
     },
-    "80419": {
-      "relative_position": 0.5196040714,
-      "stop_name": "Lake Station"
+    80419: {
+      relative_position: 0.5196040714,
+      stop_name: 'Lake Station',
     },
-    "80420": {
-      "relative_position": 0.5526316698,
-      "stop_name": "Allen Station"
+    80420: {
+      relative_position: 0.5526316698,
+      stop_name: 'Allen Station',
     },
-    "80421": {
-      "relative_position": 0.6190413519,
-      "stop_name": "Sierra Madre Villa Station"
+    80421: {
+      relative_position: 0.6190413519,
+      stop_name: 'Sierra Madre Villa Station',
     },
-    "80422": {
-      "relative_position": 0.7228540419,
-      "stop_name": "Arcadia Station"
+    80422: {
+      relative_position: 0.7228540419,
+      stop_name: 'Arcadia Station',
     },
-    "80423": {
-      "relative_position": 0.7765539292,
-      "stop_name": "Monrovia Station"
+    80423: {
+      relative_position: 0.7765539292,
+      stop_name: 'Monrovia Station',
     },
-    "80424": {
-      "relative_position": 0.8460144389,
-      "stop_name": "Duarte / City of Hope Station"
+    80424: {
+      relative_position: 0.8460144389,
+      stop_name: 'Duarte / City of Hope Station',
     },
-    "80425": {
-      "relative_position": 0.915454343,
-      "stop_name": "Irwindale Station"
+    80425: {
+      relative_position: 0.915454343,
+      stop_name: 'Irwindale Station',
     },
-    "80426": {
-      "relative_position": 0.9673916852,
-      "stop_name": "Azusa Downtown Station"
+    80426: {
+      relative_position: 0.9673916852,
+      stop_name: 'Azusa Downtown Station',
     },
-    "80427": {
-      "relative_position": 0.9966254589,
-      "stop_name": "APU / Citrus College Station"
-    }
+    80427: {
+      relative_position: 0.9966254589,
+      stop_name: 'APU / Citrus College Station',
+    },
   },
-  "805_0": {
-    "80216": {
-      "relative_position": 0.013007261,
-      "stop_name": "Wilshire / Western Station"
+  '805_0': {
+    80216: {
+      relative_position: 0.013007261,
+      stop_name: 'Wilshire / Western Station',
     },
-    "80215": {
-      "relative_position": 0.0976357772,
-      "stop_name": "Wilshire / Normandie Station"
+    80215: {
+      relative_position: 0.0976357772,
+      stop_name: 'Wilshire / Normandie Station',
     },
-    "80209": {
-      "relative_position": 0.2357941731,
-      "stop_name": "Wilshire / Vermont Station"
+    80209: {
+      relative_position: 0.2357941731,
+      stop_name: 'Wilshire / Vermont Station',
     },
-    "80210": {
-      "relative_position": 0.431783208,
-      "stop_name": "Westlake / MacArthur Park Station"
+    80210: {
+      relative_position: 0.431783208,
+      stop_name: 'Westlake / MacArthur Park Station',
     },
-    "80211": {
-      "relative_position": 0.6411988556,
-      "stop_name": "7th Street / Metro Center Station - Metro Red & Purple Lines"
+    80211: {
+      relative_position: 0.6411988556,
+      stop_name: '7th Street / Metro Center Station - Metro Red & Purple Lines',
     },
-    "80212": {
-      "relative_position": 0.7426543648,
-      "stop_name": "Pershing Square Station"
+    80212: {
+      relative_position: 0.7426543648,
+      stop_name: 'Pershing Square Station',
     },
-    "80213": {
-      "relative_position": 0.8311442662,
-      "stop_name": "Civic Center / Grand Park Station"
+    80213: {
+      relative_position: 0.8311442662,
+      stop_name: 'Civic Center / Grand Park Station',
     },
-    "80214": {
-      "relative_position": 0.9855060742,
-      "stop_name": "Union Station - Metro Red & Purple Lines"
-    }
+    80214: {
+      relative_position: 0.9855060742,
+      stop_name: 'Union Station - Metro Red & Purple Lines',
+    },
   },
-  "806_0": {
-    "80139": {
-      "relative_position": 0.0015282507,
-      "stop_name": "Downtown Santa Monica Station"
+  '806_0': {
+    80139: {
+      relative_position: 0.0015282507,
+      stop_name: 'Downtown Santa Monica Station',
     },
-    "80138": {
-      "relative_position": 0.0571685976,
-      "stop_name": "17th Street / SMC Station"
+    80138: {
+      relative_position: 0.0571685976,
+      stop_name: '17th Street / SMC Station',
     },
-    "80137": {
-      "relative_position": 0.1049719213,
-      "stop_name": "26th Street / Bergamot Station"
+    80137: {
+      relative_position: 0.1049719213,
+      stop_name: '26th Street / Bergamot Station',
     },
-    "80136": {
-      "relative_position": 0.169623833,
-      "stop_name": "Expo / Bundy Station"
+    80136: {
+      relative_position: 0.169623833,
+      stop_name: 'Expo / Bundy Station',
     },
-    "80135": {
-      "relative_position": 0.2434752985,
-      "stop_name": "Expo / Sepulveda Station"
+    80135: {
+      relative_position: 0.2434752985,
+      stop_name: 'Expo / Sepulveda Station',
     },
-    "80134": {
-      "relative_position": 0.2813582919,
-      "stop_name": "Westwood / Rancho Park Station"
+    80134: {
+      relative_position: 0.2813582919,
+      stop_name: 'Westwood / Rancho Park Station',
     },
-    "80133": {
-      "relative_position": 0.3709216343,
-      "stop_name": "Palms Station"
+    80133: {
+      relative_position: 0.3709216343,
+      stop_name: 'Palms Station',
     },
-    "80132": {
-      "relative_position": 0.4304492622,
-      "stop_name": "Culver City Station"
+    80132: {
+      relative_position: 0.4304492622,
+      stop_name: 'Culver City Station',
     },
-    "80131": {
-      "relative_position": 0.4962151298,
-      "stop_name": "La Cienega / Jefferson Station"
+    80131: {
+      relative_position: 0.4962151298,
+      stop_name: 'La Cienega / Jefferson Station',
     },
-    "80130": {
-      "relative_position": 0.5623310182,
-      "stop_name": "Expo / La Brea / Ethel Bradley Station"
+    80130: {
+      relative_position: 0.5623310182,
+      stop_name: 'Expo / La Brea / Ethel Bradley Station',
     },
-    "80129": {
-      "relative_position": 0.5976553568,
-      "stop_name": "Farmdale Station"
+    80129: {
+      relative_position: 0.5976553568,
+      stop_name: 'Farmdale Station',
     },
-    "80128": {
-      "relative_position": 0.6407903461,
-      "stop_name": "Expo / Crenshaw Station"
+    80128: {
+      relative_position: 0.6407903461,
+      stop_name: 'Expo / Crenshaw Station',
     },
-    "80127": {
-      "relative_position": 0.7440394737,
-      "stop_name": "Expo / Western Station"
+    80127: {
+      relative_position: 0.7440394737,
+      stop_name: 'Expo / Western Station',
     },
-    "80126": {
-      "relative_position": 0.8114602088,
-      "stop_name": "Expo / Vermont Station"
+    80126: {
+      relative_position: 0.8114602088,
+      stop_name: 'Expo / Vermont Station',
     },
-    "80125": {
-      "relative_position": 0.8339960647,
-      "stop_name": "Expo Park / USC Station"
+    80125: {
+      relative_position: 0.8339960647,
+      stop_name: 'Expo Park / USC Station',
     },
-    "80124": {
-      "relative_position": 0.8713603565,
-      "stop_name": "Jefferson / USC Station"
+    80124: {
+      relative_position: 0.8713603565,
+      stop_name: 'Jefferson / USC Station',
     },
-    "80123": {
-      "relative_position": 0.9038420962,
-      "stop_name": "LATTC / Ortho Institute Station"
+    80123: {
+      relative_position: 0.9038420962,
+      stop_name: 'LATTC / Ortho Institute Station',
     },
-    "80121": {
-      "relative_position": 0.9575725551,
-      "stop_name": "Pico Station"
+    80121: {
+      relative_position: 0.9575725551,
+      stop_name: 'Pico Station',
     },
-    "80122": {
-      "relative_position": 0.9992335737,
-      "stop_name": "7th Street / Metro Center Station - Metro Blue & Expo Lines"
-    }
+    80122: {
+      relative_position: 0.9992335737,
+      stop_name: '7th Street / Metro Center Station - Metro Blue & Expo Lines',
+    },
   },
-  "801_1": {
-    "80122": {
-      "relative_position": 0.0005562556,
-      "stop_name": "7th Street / Metro Center Station - Metro Blue & Expo Lines"
+  '801_1': {
+    80122: {
+      relative_position: 0.0005562556,
+      stop_name: '7th Street / Metro Center Station - Metro Blue & Expo Lines',
     },
-    "80121": {
-      "relative_position": 0.0343268812,
-      "stop_name": "Pico Station"
+    80121: {
+      relative_position: 0.0343268812,
+      stop_name: 'Pico Station',
     },
-    "80120": {
-      "relative_position": 0.064950695,
-      "stop_name": "Grand / LATTC Station"
+    80120: {
+      relative_position: 0.064950695,
+      stop_name: 'Grand / LATTC Station',
     },
-    "80119": {
-      "relative_position": 0.1128107799,
-      "stop_name": "San Pedro Street Station"
+    80119: {
+      relative_position: 0.1128107799,
+      stop_name: 'San Pedro Street Station',
     },
-    "80118": {
-      "relative_position": 0.1592246249,
-      "stop_name": "Washington Station"
+    80118: {
+      relative_position: 0.1592246249,
+      stop_name: 'Washington Station',
     },
-    "80117": {
-      "relative_position": 0.2118580663,
-      "stop_name": "Vernon Station"
+    80117: {
+      relative_position: 0.2118580663,
+      stop_name: 'Vernon Station',
     },
-    "80116": {
-      "relative_position": 0.2564057004,
-      "stop_name": "Slauson Station"
+    80116: {
+      relative_position: 0.2564057004,
+      stop_name: 'Slauson Station',
     },
-    "80115": {
-      "relative_position": 0.3036523457,
-      "stop_name": "Florence Station"
+    80115: {
+      relative_position: 0.3036523457,
+      stop_name: 'Florence Station',
     },
-    "80114": {
-      "relative_position": 0.3480978625,
-      "stop_name": "Firestone Station"
+    80114: {
+      relative_position: 0.3480978625,
+      stop_name: 'Firestone Station',
     },
-    "80113": {
-      "relative_position": 0.4028056384,
-      "stop_name": "103rd Street / Watts Towers  Station"
+    80113: {
+      relative_position: 0.4028056384,
+      stop_name: '103rd Street / Watts Towers  Station',
     },
-    "80112": {
-      "relative_position": 0.4515488018,
-      "stop_name": "Willowbrook - Rosa Parks Station - Metro Blue Line"
+    80112: {
+      relative_position: 0.4515488018,
+      stop_name: 'Willowbrook - Rosa Parks Station - Metro Blue Line',
     },
-    "80111": {
-      "relative_position": 0.5574566169,
-      "stop_name": "Compton Station"
+    80111: {
+      relative_position: 0.5574566169,
+      stop_name: 'Compton Station',
     },
-    "80110": {
-      "relative_position": 0.6251635365,
-      "stop_name": "Artesia Station"
+    80110: {
+      relative_position: 0.6251635365,
+      stop_name: 'Artesia Station',
     },
-    "80109": {
-      "relative_position": 0.7199730776,
-      "stop_name": "Del Amo Station"
+    80109: {
+      relative_position: 0.7199730776,
+      stop_name: 'Del Amo Station',
     },
-    "80108": {
-      "relative_position": 0.8211789192,
-      "stop_name": "Wardlow Station"
+    80108: {
+      relative_position: 0.8211789192,
+      stop_name: 'Wardlow Station',
     },
-    "80107": {
-      "relative_position": 0.8659976599,
-      "stop_name": "Willow Street Station"
+    80107: {
+      relative_position: 0.8659976599,
+      stop_name: 'Willow Street Station',
     },
-    "80106": {
-      "relative_position": 0.9229145476,
-      "stop_name": "Pacific Coast Hwy Station"
+    80106: {
+      relative_position: 0.9229145476,
+      stop_name: 'Pacific Coast Hwy Station',
     },
-    "80105": {
-      "relative_position": 0.9457516388,
-      "stop_name": "Anaheim Street Station"
+    80105: {
+      relative_position: 0.9457516388,
+      stop_name: 'Anaheim Street Station',
     },
-    "80154": {
-      "relative_position": 0.971675132,
-      "stop_name": "5th Street Station"
+    80154: {
+      relative_position: 0.971675132,
+      stop_name: '5th Street Station',
     },
-    "80153": {
-      "relative_position": 0.9869657239,
-      "stop_name": "1st Street Station"
+    80153: {
+      relative_position: 0.9869657239,
+      stop_name: '1st Street Station',
     },
-    "80101": {
-      "relative_position": 0.9998309528,
-      "stop_name": "Downtown Long Beach Station"
-    }
+    80101: {
+      relative_position: 0.9998309528,
+      stop_name: 'Downtown Long Beach Station',
+    },
   },
-  "802_1": {
-    "80214": {
-      "relative_position": 0.0055136089,
-      "stop_name": "Union Station - Metro Red & Purple Lines"
+  '802_1': {
+    80214: {
+      relative_position: 0.0055136089,
+      stop_name: 'Union Station - Metro Red & Purple Lines',
     },
-    "80213": {
-      "relative_position": 0.0624251075,
-      "stop_name": "Civic Center / Grand Park Station"
+    80213: {
+      relative_position: 0.0624251075,
+      stop_name: 'Civic Center / Grand Park Station',
     },
-    "80212": {
-      "relative_position": 0.0946122407,
-      "stop_name": "Pershing Square Station"
+    80212: {
+      relative_position: 0.0946122407,
+      stop_name: 'Pershing Square Station',
     },
-    "80211": {
-      "relative_position": 0.1307973461,
-      "stop_name": "7th Street / Metro Center Station - Metro Red & Purple Lines"
+    80211: {
+      relative_position: 0.1307973461,
+      stop_name: '7th Street / Metro Center Station - Metro Red & Purple Lines',
     },
-    "80210": {
-      "relative_position": 0.2069404197,
-      "stop_name": "Westlake / MacArthur Park Station"
+    80210: {
+      relative_position: 0.2069404197,
+      stop_name: 'Westlake / MacArthur Park Station',
     },
-    "80209": {
-      "relative_position": 0.2784442835,
-      "stop_name": "Wilshire / Vermont Station"
+    80209: {
+      relative_position: 0.2784442835,
+      stop_name: 'Wilshire / Vermont Station',
     },
-    "80208": {
-      "relative_position": 0.3436315656,
-      "stop_name": "Vermont / Beverly Station"
+    80208: {
+      relative_position: 0.3436315656,
+      stop_name: 'Vermont / Beverly Station',
     },
-    "80207": {
-      "relative_position": 0.4000771567,
-      "stop_name": "Vermont / Santa Monica Station"
+    80207: {
+      relative_position: 0.4000771567,
+      stop_name: 'Vermont / Santa Monica Station',
     },
-    "80206": {
-      "relative_position": 0.432964394,
-      "stop_name": "Vermont / Sunset Station"
+    80206: {
+      relative_position: 0.432964394,
+      stop_name: 'Vermont / Sunset Station',
     },
-    "80205": {
-      "relative_position": 0.5138973436,
-      "stop_name": "Hollywood / Western Station"
+    80205: {
+      relative_position: 0.5138973436,
+      stop_name: 'Hollywood / Western Station',
     },
-    "80204": {
-      "relative_position": 0.5858607036,
-      "stop_name": "Hollywood / Vine Station"
+    80204: {
+      relative_position: 0.5858607036,
+      stop_name: 'Hollywood / Vine Station',
     },
-    "80203": {
-      "relative_position": 0.6422436831,
-      "stop_name": "Hollywood / Highland Station"
+    80203: {
+      relative_position: 0.6422436831,
+      stop_name: 'Hollywood / Highland Station',
     },
-    "80202": {
-      "relative_position": 0.8511230406,
-      "stop_name": "Universal / Studio City Station"
+    80202: {
+      relative_position: 0.8511230406,
+      stop_name: 'Universal / Studio City Station',
     },
-    "80201": {
-      "relative_position": 0.9886028758,
-      "stop_name": "North Hollywood Station"
-    }
+    80201: {
+      relative_position: 0.9886028758,
+      stop_name: 'North Hollywood Station',
+    },
   },
-  "803_1": {
-    "80314": {
-      "relative_position": 0.0109745211,
-      "stop_name": "Norwalk Station"
+  '803_1': {
+    80314: {
+      relative_position: 0.0109745211,
+      stop_name: 'Norwalk Station',
     },
-    "80313": {
-      "relative_position": 0.1177044657,
-      "stop_name": "Lakewood Blvd Station"
+    80313: {
+      relative_position: 0.1177044657,
+      stop_name: 'Lakewood Blvd Station',
     },
-    "80312": {
-      "relative_position": 0.3317636497,
-      "stop_name": "Long Beach Blvd Station"
+    80312: {
+      relative_position: 0.3317636497,
+      stop_name: 'Long Beach Blvd Station',
     },
-    "80311": {
-      "relative_position": 0.4185852512,
-      "stop_name": "Willowbrook - Rosa Parks Station - Metro Green Line"
+    80311: {
+      relative_position: 0.4185852512,
+      stop_name: 'Willowbrook - Rosa Parks Station - Metro Green Line',
     },
-    "80310": {
-      "relative_position": 0.4996082186,
-      "stop_name": "Avalon Station"
+    80310: {
+      relative_position: 0.4996082186,
+      stop_name: 'Avalon Station',
     },
-    "80309": {
-      "relative_position": 0.5471516967,
-      "stop_name": "Harbor Freeway Station"
+    80309: {
+      relative_position: 0.5471516967,
+      stop_name: 'Harbor Freeway Station',
     },
-    "80308": {
-      "relative_position": 0.5787573497,
-      "stop_name": "Vermont / Athens Station"
+    80308: {
+      relative_position: 0.5787573497,
+      stop_name: 'Vermont / Athens Station',
     },
-    "80307": {
-      "relative_position": 0.6832199992,
-      "stop_name": "Crenshaw Station"
+    80307: {
+      relative_position: 0.6832199992,
+      stop_name: 'Crenshaw Station',
     },
-    "80306": {
-      "relative_position": 0.764273912,
-      "stop_name": "Hawthorne / Lennox Station"
+    80306: {
+      relative_position: 0.764273912,
+      stop_name: 'Hawthorne / Lennox Station',
     },
-    "80305": {
-      "relative_position": 0.8417961485,
-      "stop_name": "Aviation / LAX Station"
+    80305: {
+      relative_position: 0.8417961485,
+      stop_name: 'Aviation / LAX Station',
     },
-    "80304": {
-      "relative_position": 0.8864667672,
-      "stop_name": "Mariposa Station"
+    80304: {
+      relative_position: 0.8864667672,
+      stop_name: 'Mariposa Station',
     },
-    "80303": {
-      "relative_position": 0.9090127495,
-      "stop_name": "El Segundo Station"
+    80303: {
+      relative_position: 0.9090127495,
+      stop_name: 'El Segundo Station',
     },
-    "80302": {
-      "relative_position": 0.9450493338,
-      "stop_name": "Douglas Station"
+    80302: {
+      relative_position: 0.9450493338,
+      stop_name: 'Douglas Station',
     },
-    "80301": {
-      "relative_position": 0.9971642913,
-      "stop_name": "Redondo Beach Station"
-    }
+    80301: {
+      relative_position: 0.9971642913,
+      stop_name: 'Redondo Beach Station',
+    },
   },
-  "804_1": {
-    "80427": {
-      "relative_position": 0.0033715085,
-      "stop_name": "APU / Citrus College Station"
+  '804_1': {
+    80427: {
+      relative_position: 0.0033715085,
+      stop_name: 'APU / Citrus College Station',
     },
-    "80426": {
-      "relative_position": 0.0325944627,
-      "stop_name": "Azusa Downtown Station"
+    80426: {
+      relative_position: 0.0325944627,
+      stop_name: 'Azusa Downtown Station',
     },
-    "80425": {
-      "relative_position": 0.0844860661,
-      "stop_name": "Irwindale Station"
+    80425: {
+      relative_position: 0.0844860661,
+      stop_name: 'Irwindale Station',
     },
-    "80424": {
-      "relative_position": 0.1538827873,
-      "stop_name": "Duarte / City of Hope Station"
+    80424: {
+      relative_position: 0.1538827873,
+      stop_name: 'Duarte / City of Hope Station',
     },
-    "80423": {
-      "relative_position": 0.2232830119,
-      "stop_name": "Monrovia Station"
+    80423: {
+      relative_position: 0.2232830119,
+      stop_name: 'Monrovia Station',
     },
-    "80422": {
-      "relative_position": 0.2769263796,
-      "stop_name": "Arcadia Station"
+    80422: {
+      relative_position: 0.2769263796,
+      stop_name: 'Arcadia Station',
     },
-    "80421": {
-      "relative_position": 0.3807289833,
-      "stop_name": "Sierra Madre Villa Station"
+    80421: {
+      relative_position: 0.3807289833,
+      stop_name: 'Sierra Madre Villa Station',
     },
-    "80420": {
-      "relative_position": 0.4470857419,
-      "stop_name": "Allen Station"
+    80420: {
+      relative_position: 0.4470857419,
+      stop_name: 'Allen Station',
     },
-    "80419": {
-      "relative_position": 0.4800919281,
-      "stop_name": "Lake Station"
+    80419: {
+      relative_position: 0.4800919281,
+      stop_name: 'Lake Station',
     },
-    "80418": {
-      "relative_position": 0.515137293,
-      "stop_name": "Memorial Park Station"
+    80418: {
+      relative_position: 0.515137293,
+      stop_name: 'Memorial Park Station',
     },
-    "80417": {
-      "relative_position": 0.5279527714,
-      "stop_name": "Del Mar Station"
+    80417: {
+      relative_position: 0.5279527714,
+      stop_name: 'Del Mar Station',
     },
-    "80416": {
-      "relative_position": 0.5441878445,
-      "stop_name": "Fillmore Station"
+    80416: {
+      relative_position: 0.5441878445,
+      stop_name: 'Fillmore Station',
     },
-    "80415": {
-      "relative_position": 0.5881884133,
-      "stop_name": "South Pasadena Station"
+    80415: {
+      relative_position: 0.5881884133,
+      stop_name: 'South Pasadena Station',
     },
-    "80414": {
-      "relative_position": 0.6585101464,
-      "stop_name": "Highland Park Station"
+    80414: {
+      relative_position: 0.6585101464,
+      stop_name: 'Highland Park Station',
     },
-    "80413": {
-      "relative_position": 0.698555377,
-      "stop_name": "Southwest Museum Station"
+    80413: {
+      relative_position: 0.698555377,
+      stop_name: 'Southwest Museum Station',
     },
-    "80412": {
-      "relative_position": 0.724807738,
-      "stop_name": "Heritage Square / Arroyo Station"
+    80412: {
+      relative_position: 0.724807738,
+      stop_name: 'Heritage Square / Arroyo Station',
     },
-    "80411": {
-      "relative_position": 0.7433438626,
-      "stop_name": "Lincoln Heights / Cypress Park Station"
+    80411: {
+      relative_position: 0.7433438626,
+      stop_name: 'Lincoln Heights / Cypress Park Station',
     },
-    "80410": {
-      "relative_position": 0.7903689072,
-      "stop_name": "Chinatown Station"
+    80410: {
+      relative_position: 0.7903689072,
+      stop_name: 'Chinatown Station',
     },
-    "80409": {
-      "relative_position": 0.808575234,
-      "stop_name": "Union Station - Metro Gold Line"
+    80409: {
+      relative_position: 0.808575234,
+      stop_name: 'Union Station - Metro Gold Line',
     },
-    "80408": {
-      "relative_position": 0.8245798952,
-      "stop_name": "Little Tokyo / Arts District Station"
+    80408: {
+      relative_position: 0.8245798952,
+      stop_name: 'Little Tokyo / Arts District Station',
     },
-    "80407": {
-      "relative_position": 0.8498702817,
-      "stop_name": "Pico / Aliso Station"
+    80407: {
+      relative_position: 0.8498702817,
+      stop_name: 'Pico / Aliso Station',
     },
-    "80406": {
-      "relative_position": 0.8620696597,
-      "stop_name": "Mariachi Plaza / Boyle Heights Station"
+    80406: {
+      relative_position: 0.8620696597,
+      stop_name: 'Mariachi Plaza / Boyle Heights Station',
     },
-    "80405": {
-      "relative_position": 0.8820415857,
-      "stop_name": "Soto Station"
+    80405: {
+      relative_position: 0.8820415857,
+      stop_name: 'Soto Station',
     },
-    "80404": {
-      "relative_position": 0.9225625884,
-      "stop_name": "Indiana Station"
+    80404: {
+      relative_position: 0.9225625884,
+      stop_name: 'Indiana Station',
     },
-    "80403": {
-      "relative_position": 0.9708352019,
-      "stop_name": "Maravilla Station"
+    80403: {
+      relative_position: 0.9708352019,
+      stop_name: 'Maravilla Station',
     },
-    "80402": {
-      "relative_position": 0.9842507658,
-      "stop_name": "East LA Civic Center Station"
+    80402: {
+      relative_position: 0.9842507658,
+      stop_name: 'East LA Civic Center Station',
     },
-    "80401": {
-      "relative_position": 0.997285367,
-      "stop_name": "Atlantic Station"
-    }
+    80401: {
+      relative_position: 0.997285367,
+      stop_name: 'Atlantic Station',
+    },
   },
-  "805_1": {
-    "80214": {
-      "relative_position": 0.0151429796,
-      "stop_name": "Union Station - Metro Red & Purple Lines"
+  '805_1': {
+    80214: {
+      relative_position: 0.0151429796,
+      stop_name: 'Union Station - Metro Red & Purple Lines',
     },
-    "80213": {
-      "relative_position": 0.1714488907,
-      "stop_name": "Civic Center / Grand Park Station"
+    80213: {
+      relative_position: 0.1714488907,
+      stop_name: 'Civic Center / Grand Park Station',
     },
-    "80212": {
-      "relative_position": 0.2598499926,
-      "stop_name": "Pershing Square Station"
+    80212: {
+      relative_position: 0.2598499926,
+      stop_name: 'Pershing Square Station',
     },
-    "80211": {
-      "relative_position": 0.3592314182,
-      "stop_name": "7th Street / Metro Center Station - Metro Red & Purple Lines"
+    80211: {
+      relative_position: 0.3592314182,
+      stop_name: '7th Street / Metro Center Station - Metro Red & Purple Lines',
     },
-    "80210": {
-      "relative_position": 0.5683563366,
-      "stop_name": "Westlake / MacArthur Park Station"
+    80210: {
+      relative_position: 0.5683563366,
+      stop_name: 'Westlake / MacArthur Park Station',
     },
-    "80209": {
-      "relative_position": 0.764739789,
-      "stop_name": "Wilshire / Vermont Station"
+    80209: {
+      relative_position: 0.764739789,
+      stop_name: 'Wilshire / Vermont Station',
     },
-    "80215": {
-      "relative_position": 0.9024688421,
-      "stop_name": "Wilshire / Normandie Station"
+    80215: {
+      relative_position: 0.9024688421,
+      stop_name: 'Wilshire / Normandie Station',
     },
-    "80216": {
-      "relative_position": 0.987003723,
-      "stop_name": "Wilshire / Western Station"
-    }
+    80216: {
+      relative_position: 0.987003723,
+      stop_name: 'Wilshire / Western Station',
+    },
   },
-  "806_1": {
-    "80122": {
-      "relative_position": 0.0005580173,
-      "stop_name": "7th Street / Metro Center Station - Metro Blue & Expo Lines"
+  '806_1': {
+    80122: {
+      relative_position: 0.0005580173,
+      stop_name: '7th Street / Metro Center Station - Metro Blue & Expo Lines',
     },
-    "80121": {
-      "relative_position": 0.0422353832,
-      "stop_name": "Pico Station"
+    80121: {
+      relative_position: 0.0422353832,
+      stop_name: 'Pico Station',
     },
-    "80123": {
-      "relative_position": 0.0960152771,
-      "stop_name": "LATTC / Ortho Institute Station"
+    80123: {
+      relative_position: 0.0960152771,
+      stop_name: 'LATTC / Ortho Institute Station',
     },
-    "80124": {
-      "relative_position": 0.1284864322,
-      "stop_name": "Jefferson / USC Station"
+    80124: {
+      relative_position: 0.1284864322,
+      stop_name: 'Jefferson / USC Station',
     },
-    "80125": {
-      "relative_position": 0.1656232148,
-      "stop_name": "Expo Park / USC Station"
+    80125: {
+      relative_position: 0.1656232148,
+      stop_name: 'Expo Park / USC Station',
     },
-    "80126": {
-      "relative_position": 0.1881598179,
-      "stop_name": "Expo / Vermont Station"
+    80126: {
+      relative_position: 0.1881598179,
+      stop_name: 'Expo / Vermont Station',
     },
-    "80127": {
-      "relative_position": 0.255589438,
-      "stop_name": "Expo / Western Station"
+    80127: {
+      relative_position: 0.255589438,
+      stop_name: 'Expo / Western Station',
     },
-    "80128": {
-      "relative_position": 0.3588246824,
-      "stop_name": "Expo / Crenshaw Station"
+    80128: {
+      relative_position: 0.3588246824,
+      stop_name: 'Expo / Crenshaw Station',
     },
-    "80129": {
-      "relative_position": 0.4019814654,
-      "stop_name": "Farmdale Station"
+    80129: {
+      relative_position: 0.4019814654,
+      stop_name: 'Farmdale Station',
     },
-    "80130": {
-      "relative_position": 0.4373113354,
-      "stop_name": "Expo / La Brea / Ethel Bradley Station"
+    80130: {
+      relative_position: 0.4373113354,
+      stop_name: 'Expo / La Brea / Ethel Bradley Station',
     },
-    "80131": {
-      "relative_position": 0.5034348928,
-      "stop_name": "La Cienega / Jefferson Station"
+    80131: {
+      relative_position: 0.5034348928,
+      stop_name: 'La Cienega / Jefferson Station',
     },
-    "80132": {
-      "relative_position": 0.5691837537,
-      "stop_name": "Culver City Station"
+    80132: {
+      relative_position: 0.5691837537,
+      stop_name: 'Culver City Station',
     },
-    "80133": {
-      "relative_position": 0.6287160228,
-      "stop_name": "Palms Station"
+    80133: {
+      relative_position: 0.6287160228,
+      stop_name: 'Palms Station',
     },
-    "80134": {
-      "relative_position": 0.7183446777,
-      "stop_name": "Westwood / Rancho Park Station"
+    80134: {
+      relative_position: 0.7183446777,
+      stop_name: 'Westwood / Rancho Park Station',
     },
-    "80135": {
-      "relative_position": 0.7562349647,
-      "stop_name": "Expo / Sepulveda Station"
+    80135: {
+      relative_position: 0.7562349647,
+      stop_name: 'Expo / Sepulveda Station',
     },
-    "80136": {
-      "relative_position": 0.8301123786,
-      "stop_name": "Expo / Bundy Station"
+    80136: {
+      relative_position: 0.8301123786,
+      stop_name: 'Expo / Bundy Station',
     },
-    "80137": {
-      "relative_position": 0.8947935559,
-      "stop_name": "26th Street / Bergamot Station"
+    80137: {
+      relative_position: 0.8947935559,
+      stop_name: '26th Street / Bergamot Station',
     },
-    "80138": {
-      "relative_position": 0.9426962554,
-      "stop_name": "17th Street / SMC Station"
+    80138: {
+      relative_position: 0.9426962554,
+      stop_name: '17th Street / SMC Station',
     },
-    "80139": {
-      "relative_position": 0.9984136235,
-      "stop_name": "Downtown Santa Monica Station"
-    }
-  }
-}
-
+    80139: {
+      relative_position: 0.9984136235,
+      stop_name: 'Downtown Santa Monica Station',
+    },
+  },
+};

--- a/helpers/formatHistory.js
+++ b/helpers/formatHistory.js
@@ -2,97 +2,90 @@ import { lines, linesByName } from './LineInfo.js';
 
 
 const dateToString = (diff) => {
-  let d = new Date();
+  const d = new Date();
   d.setDate(d.getDate() - diff);
-  
-  let month = '' + (d.getMonth() + 1);
-  let day = '' + d.getDate();
 
-  return [month,day].join('/');
-}
+  const month = `${d.getMonth() + 1}`;
+  const day = `${d.getDate()}`;
+
+  return [month, day].join('/');
+};
 
 const deriveLine = (data, line, allLineData) => {
-    if (line === "All Lines") {
-      return allLineData;
-    } else {
-      const lineNum = linesByName[line].id;
-      return data.map(datum => datum[`${lineNum}_lametro-rail`]);
-    }
-}
+  if (line === 'All Lines') {
+    return allLineData;
+  }
+  const lineNum = linesByName[line].id;
+  return data.map(datum => datum[`${lineNum}_lametro-rail`]);
+};
 
 const deriveXAxis = (data, axisLabel) => {
-  switch(axisLabel) {
-    case "Weekday Average":
-      let weekDayArr = [[],[],[],[],[],[],[]]
-      for (let item of data) {
+  switch (axisLabel) {
+    case 'Weekday Average':
+      const weekDayArr = [[], [], [], [], [], [], []];
+      for (const item of data) {
         weekDayArr[new Date(item.date).getDay()].push(item);
       }
       const formattedWeekDayArr = weekDayArr.map(item => getAverageStats(item));
       return formattedWeekDayArr;
-    case "Last 30 Days":
-      const lastThirtyArr = data.slice(data.length-30, data.length);
+    case 'Last 30 Days':
+      const lastThirtyArr = data.slice(data.length - 30, data.length);
       const formattedLastThirtyArr = lastThirtyArr.map(currItem => ({
         wait: currItem.mean_time_between / 60,
-        oneMin: currItem.ontime["1_min"] / currItem.total_arrivals_analyzed * 100,
-        fiveMin: currItem.ontime["5_min"] / currItem.total_arrivals_analyzed * 100,
-      }))
+        oneMin: currItem.ontime['1_min'] / currItem.total_arrivals_analyzed * 100,
+        fiveMin: currItem.ontime['5_min'] / currItem.total_arrivals_analyzed * 100,
+      }));
       return formattedLastThirtyArr;
-    case "Weekly Average":
+    case 'Weekly Average':
       const weeklyArr = [];
-      let d = new Date(data[0].date);
+      const d = new Date(data[0].date);
       d.setDate(d.getDate() + 1);
-      let firstNum = d.getDay();
-      let firstArrLength = 7 - firstNum;
+      const firstNum = d.getDay();
+      const firstArrLength = 7 - firstNum;
       weeklyArr.push(data.slice(0, firstArrLength));
-      for (let i = firstArrLength; i < data.length; i+=7) {
-        weeklyArr.push(data.slice(i, i+7));
+      for (let i = firstArrLength; i < data.length; i += 7) {
+        weeklyArr.push(data.slice(i, i + 7));
       }
-      const formattedWeeklyArr = weeklyArr.map(item => getAverageStats(item))
+      const formattedWeeklyArr = weeklyArr.map(item => getAverageStats(item));
       return formattedWeeklyArr;
-    case "All Daily Data":
+    case 'All Daily Data':
       const dailyArr = data.map(currItem => ({
         wait: currItem.mean_time_between / 60,
-        oneMin: currItem.ontime["1_min"] / currItem.total_arrivals_analyzed * 100,
-        fiveMin: currItem.ontime["5_min"] / currItem.total_arrivals_analyzed * 100,
-      }))
+        oneMin: currItem.ontime['1_min'] / currItem.total_arrivals_analyzed * 100,
+        fiveMin: currItem.ontime['5_min'] / currItem.total_arrivals_analyzed * 100,
+      }));
       return dailyArr;
     default:
-       return data;
+      return data;
   }
-}
+};
 
 const getAverageStats = (arr) => {
   const wait = arr.reduce((acc, currItem) => acc + currItem.mean_time_between, 0) / arr.length / 60;
-  const oneMin = arr.reduce((acc, currItem) => acc + currItem.ontime["1_min"] / currItem.total_arrivals_analyzed, 0) / arr.length * 100;
-  const fiveMin = arr.reduce((acc, currItem) => acc + currItem.ontime["5_min"] / currItem.total_arrivals_analyzed, 0) / arr.length * 100;
+  const oneMin = arr.reduce((acc, currItem) => acc + currItem.ontime['1_min'] / currItem.total_arrivals_analyzed, 0) / arr.length * 100;
+  const fiveMin = arr.reduce((acc, currItem) => acc + currItem.ontime['5_min'] / currItem.total_arrivals_analyzed, 0) / arr.length * 100;
   return {
     wait,
     oneMin,
-    fiveMin
-  }
-}
+    fiveMin,
+  };
+};
 
 const deriveYAxis = (data, axisLabel) => {
-  switch(axisLabel) {
-    case "Average Wait Time":
-      return data.map((item, i) => {
-        return item.wait;
-      });
-    case "% Within 1 Minute":
-      return data.map((item, i) => {
-        return item.oneMin;        
-      });
-    case "% Within 5 Minutes":
-    return data.map((item, i) => {
-        return item.fiveMin;
-      });
+  switch (axisLabel) {
+    case 'Average Wait Time':
+      return data.map((item, i) => item.wait);
+    case '% Within 1 Minute':
+      return data.map((item, i) => item.oneMin);
+    case '% Within 5 Minutes':
+      return data.map((item, i) => item.fiveMin);
     default:
-       return data;
+      return data;
   }
-}
+};
 
-const prepareTableData = (data) => {
-    return data.slice(0,data.length).reverse().map((item,i) => Object.assign(item,{ id: i }))
-}
+const prepareTableData = data => data.slice(0, data.length).reverse().map((item, i) => Object.assign(item, { id: i }));
 
-export { dateToString, deriveLine, deriveXAxis, deriveYAxis, prepareTableData };
+export {
+  dateToString, deriveLine, deriveXAxis, deriveYAxis, prepareTableData,
+};

--- a/models/LinePropType.js
+++ b/models/LinePropType.js
@@ -1,0 +1,15 @@
+import PropTypes from 'prop-types';
+
+const LinePropType = PropTypes.shape({
+  coverage: PropTypes.number,
+  date: PropTypes.string,
+  mean_secs: PropTypes.number,
+  mean_time_between: PropTypes.number,
+  ontime: PropTypes.object,
+  std_secs: PropTypes.number,
+  timestamp: PropTypes.string,
+  total_arrivals_analyzed: PropTypes.number,
+  total_scheduled_arrivals: PropTypes.number,
+});
+
+export default LinePropType;

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "eslint-loader": "^2.1.1",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.2",
-    "eslint-plugin-railstats": "file:./eslint",
     "eslint-plugin-react": "^7.11.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "node server.js",
-    "build": "next build",
-    "start": "NODE_ENV=production node server.js",
+    "build": "npm run lint && next build",
+    "start": "npm run lint && NODE_ENV=production node server.js",
     "export": "next export",
-    "lint": "eslint src/*.js components/*.jsx components/**/*.jsx pages/*.jsx pages/**/*.jsx"
+    "lint": "eslint src/*.js components/*.jsx components/**/*.jsx pages/*.jsx pages/**/*.jsx models/*.js"
   },
   "repository": {
     "type": "git",
@@ -70,6 +70,7 @@
     "eslint-loader": "^2.1.1",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.2",
+    "eslint-plugin-railstats": "file:./eslint",
     "eslint-plugin-react": "^7.11.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "dev": "node server.js",
     "build": "next build",
     "start": "NODE_ENV=production node server.js",
-    "export": "next export"
+    "export": "next export",
+    "lint": "eslint src/*.js components/*.jsx components/**/*.jsx pages/*.jsx pages/**/*.jsx"
   },
   "repository": {
     "type": "git",
@@ -34,6 +35,11 @@
     "babel-preset-env": "^1.7.0",
     "classnames": "^2.2.6",
     "compression": "^1.7.3",
+    "d3-axis": "^1.0.12",
+    "d3-scale": "^3.0.0",
+    "d3-selection": "^1.4.0",
+    "d3-shape": "^1.3.5",
+    "d3-time": "^1.0.11",
     "dataframe-js": "^1.3.2",
     "express": "^4.16.4",
     "file-system": "^2.2.2",

--- a/pages/about.jsx
+++ b/pages/about.jsx
@@ -2,27 +2,29 @@ import React from 'react';
 import Layout from '~/components/Layout';
 import { Grid, Typography } from '@material-ui/core';
 
-const About = (props) => {
-  return (
-    <Layout
-      pageTitle="About"
-      toolbarTitle="About"
-    >
-      <Grid container justify="center" alignItems="center" style={{ height: '50vh' }}>
-        <Grid item xs={12}>
-          <Typography align="center" paragraph>
+const About = props => (
+  <Layout
+    pageTitle="About"
+    toolbarTitle="About"
+  >
+    <Grid container justify="center" alignItems="center" style={{ height: '50vh' }}>
+      <Grid item xs={12}>
+        <Typography align="center" paragraph>
             RailStats LA is a performance monitor tool developed at Hack For LA.
-          </Typography>
-          <Typography align="center" paragraph>
-            Github: <a href="https://github.com/metro-ontime">https://github.com/metro-ontime</a>
-          </Typography>
-          <Typography align="center" paragraph>
-            Hack For LA: <a href="http://www.hackforla.org/">http://www.hackforla.org/</a>
-          </Typography>
-        </Grid>
+        </Typography>
+        <Typography align="center" paragraph>
+            Github:
+          {' '}
+          <a href="https://github.com/metro-ontime">https://github.com/metro-ontime</a>
+        </Typography>
+        <Typography align="center" paragraph>
+            Hack For LA:
+          {' '}
+          <a href="http://www.hackforla.org/">http://www.hackforla.org/</a>
+        </Typography>
       </Grid>
-    </Layout>
-  )
-};
+    </Grid>
+  </Layout>
+);
 
 export default About;

--- a/pages/about.jsx
+++ b/pages/about.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Layout from '~/components/Layout';
 import { Grid, Typography } from '@material-ui/core';
 
-const About = props => (
+const About = () => (
   <Layout
     pageTitle="About"
     toolbarTitle="About"

--- a/pages/history.jsx
+++ b/pages/history.jsx
@@ -1,13 +1,17 @@
 import React from 'react';
 import Layout from '~/components/Layout';
-import HistoryMenu from "~/components/HistoryMenu";
-import HistoryTable from "~/components/HistoryTable";
-import HistoryChart from "~/components/charts/HistoryChart";
-import { AppBar, Button, Tab, Tabs, Grid, Typography, Card, Select, MenuItem, ListItemAvatar, Avatar } from '@material-ui/core';
+import HistoryMenu from '~/components/HistoryMenu';
+import HistoryTable from '~/components/HistoryTable';
+import HistoryChart from '~/components/charts/HistoryChart';
+import {
+  AppBar, Button, Tab, Tabs, Grid, Typography, Card, Select, MenuItem, ListItemAvatar, Avatar,
+} from '@material-ui/core';
 import axios from 'axios';
 import { withStyles } from '@material-ui/core/styles';
 import { linesByName } from '../helpers/LineInfo.js';
-import { dateToString, deriveLine, deriveXAxis, deriveYAxis, prepareTableData } from "../helpers/formatHistory"
+import {
+  dateToString, deriveLine, deriveXAxis, deriveYAxis, prepareTableData,
+} from '../helpers/formatHistory';
 import PropTypes from 'prop-types';
 import CONFIG from '~/config';
 
@@ -23,25 +27,25 @@ const styles = theme => ({
     marginTop: 20,
   },
   chartContainer: {
-    margin: "auto",
-    width: "90%",
-    paddingTop:"3em",
-    paddingBottom:"3em"
-  }
+    margin: 'auto',
+    width: '90%',
+    paddingTop: '3em',
+    paddingBottom: '3em',
+  },
 });
 
 class History extends React.Component {
   state = {
     rows: [],
     graphData: [],
-    line: "All Lines",
-    xAxis: "Last 30 Days",
-    xTickFormat: new Array(30).fill("").map((item, i) => dateToString(30-i)),
-    yAxis: "Average Wait Time",
-    yTickFormat: { formatter: function() { return `${this.value} min`; } },
-    dataFormat: "chart",
+    line: 'All Lines',
+    xAxis: 'Last 30 Days',
+    xTickFormat: new Array(30).fill('').map((item, i) => dateToString(30 - i)),
+    yAxis: 'Average Wait Time',
+    yTickFormat: { formatter() { return `${this.value} min`; } },
+    dataFormat: 'chart',
     value: 0,
-    color: "#dddddd"
+    color: '#dddddd',
   };
 
   static async getInitialProps({ query, res }) {
@@ -51,50 +55,59 @@ class History extends React.Component {
     return { query, allLineData, formattedData };
   }
 
-  static getDerivedStateFromProps (props, state) {
+  static getDerivedStateFromProps(props, state) {
     if (!state.rows[0] && !state.graphData[0]) {
       return {
         rows: prepareTableData(props.allLineData),
-        graphData: deriveYAxis(deriveXAxis(deriveLine(props.formattedData, state.line, props.allLineData), state.xAxis), state.yAxis)
-      }
+        graphData: deriveYAxis(deriveXAxis(deriveLine(props.formattedData, state.line, props.allLineData), state.xAxis), state.yAxis),
+      };
     }
     return null;
   }
 
-  handleLineChange = event => {
-    this.setState({ line: event.target.value,
-                    color: linesByName[event.target.value]["color"],
-                    rows: prepareTableData(deriveLine(this.props.formattedData, event.target.value, this.props.allLineData)),
-                    graphData: deriveYAxis(deriveXAxis(deriveLine(this.props.formattedData, event.target.value, this.props.allLineData), this.state.xAxis), this.state.yAxis)
-                 });
+  handleLineChange = (event) => {
+    this.setState({
+      line: event.target.value,
+      color: linesByName[event.target.value].color,
+      rows: prepareTableData(deriveLine(this.props.formattedData, event.target.value, this.props.allLineData)),
+      graphData: deriveYAxis(deriveXAxis(deriveLine(this.props.formattedData, event.target.value, this.props.allLineData), this.state.xAxis), this.state.yAxis),
+    });
   };
 
-  handleXAxisChange = event => {
-    this.setState({ xAxis: event.target.value,
-                    graphData: deriveYAxis(deriveXAxis(deriveLine(this.props.formattedData, this.state.line, this.props.allLineData), event.target.value), this.state.yAxis),
-                 });
-    if (event.target.value === "Weekday Average") {
-      this.setState({ xTickFormat: ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"] });
+  handleXAxisChange = (event) => {
+    this.setState({
+      xAxis: event.target.value,
+      graphData: deriveYAxis(deriveXAxis(deriveLine(this.props.formattedData, this.state.line, this.props.allLineData), event.target.value), this.state.yAxis),
+    });
+    if (event.target.value === 'Weekday Average') {
+      this.setState({ xTickFormat: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'] });
     } else {
-      this.setState({ xTickFormat: new Array(30).fill("").map((item, i) => dateToString(30-i)) });
+      this.setState({ xTickFormat: new Array(30).fill('').map((item, i) => dateToString(30 - i)) });
     }
   };
 
-  handleYAxisChange = event => {
-    this.setState({ yAxis: event.target.value,
-                    graphData: deriveYAxis(deriveXAxis(deriveLine(this.props.formattedData, this.state.line, this.props.allLineData), this.state.xAxis), event.target.value),
+  handleYAxisChange = (event) => {
+    this.setState({
+      yAxis: event.target.value,
+      graphData: deriveYAxis(deriveXAxis(deriveLine(this.props.formattedData, this.state.line, this.props.allLineData), this.state.xAxis), event.target.value),
 
-                 });
-    if (event.target.value === "Average Wait Time") {
-      this.setState({ yTickFormat: { formatter: function() {
-                        return `${this.value} min`;
-                      }
-                    } });
+    });
+    if (event.target.value === 'Average Wait Time') {
+      this.setState({
+        yTickFormat: {
+          formatter() {
+            return `${this.value} min`;
+          },
+        },
+      });
     } else {
-      this.setState({ yTickFormat: { formatter: function() {
-                        return `${this.value}%`;
-                      }
-                    } });
+      this.setState({
+        yTickFormat: {
+          formatter() {
+            return `${this.value}%`;
+          },
+        },
+      });
     }
   };
 
@@ -104,7 +117,9 @@ class History extends React.Component {
 
   render() {
     const { classes } = this.props;
-    const { line, rows, dataFormat, xTickFormat, yTickFormat, color, graphData, xAxis, yAxis } = this.state;
+    const {
+      line, rows, dataFormat, xTickFormat, yTickFormat, color, graphData, xAxis, yAxis,
+    } = this.state;
     return (
       <Layout
         pageTitle="History"
@@ -121,36 +136,35 @@ class History extends React.Component {
         />
         <Card className={classes.card}>
           <Grid container justify="center" alignItems="center">
-            <Grid item xs={8}>
-            </Grid>
+            <Grid item xs={8} />
             <Grid item xs={4}>
               <AppBar position="static" color="default">
-              <Tabs
-                value={dataFormat}
-                onChange={this.handleTabChange}
-                indicatorColor="primary"
-                textColor="primary"
-                variant="fullWidth"
-              >
-                <Tab label="Chart" value="chart" />
-                <Tab label="Table" value="table" />
-              </Tabs>
-            </AppBar>
+                <Tabs
+                  value={dataFormat}
+                  onChange={this.handleTabChange}
+                  indicatorColor="primary"
+                  textColor="primary"
+                  variant="fullWidth"
+                >
+                  <Tab label="Chart" value="chart" />
+                  <Tab label="Table" value="table" />
+                </Tabs>
+              </AppBar>
             </Grid>
           </Grid>
-          { dataFormat === "chart" ?
-          <div className={classes.chartContainer}>
-          <HistoryChart
-            chartFormat={'column'}
-            graphData={graphData}
-            color={color}
-            xTickFormat={xTickFormat}
-            yTickFormat={yTickFormat}
-            yAxis={yAxis}
-            />
-          </div>
-          :
-          <HistoryTable rows={rows} />
+          { dataFormat === 'chart' ? (
+            <div className={classes.chartContainer}>
+              <HistoryChart
+                chartFormat="column"
+                graphData={graphData}
+                color={color}
+                xTickFormat={xTickFormat}
+                yTickFormat={yTickFormat}
+                yAxis={yAxis}
+              />
+            </div>
+          )
+            : <HistoryTable rows={rows} />
           }
         </Card>
       </Layout>

--- a/pages/index/index.jsx
+++ b/pages/index/index.jsx
@@ -1,23 +1,10 @@
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import axios from 'axios';
-import { Typography,
-  Grid,
-  Paper,
-  Button,
-  Card,
-  CardHeader,
-  CardMedia,
-  CardContent,
-  Tooltip
-} from '@material-ui/core';
+import { Grid } from '@material-ui/core';
 import { withStyles } from '@material-ui/core/styles';
 import withWidth from '@material-ui/core/withWidth';
 import flowRight from 'lodash/flowRight';
 import Layout from '~/components/Layout';
-import LineSelector from '~/components/LineSelector';
-import SimpleMenu from '~/components/SimpleMenu';
-import { lines } from '~/helpers/LineInfo';
-import { whenListAllObjects, whenGotS3Object } from '~/helpers/DataFinder';
 import LogoAndTitle from '~/components/LogoAndTitle';
 import PerformanceScoreCard from '~/components/scorecards/PerformanceScoreCard';
 import WaitTimeScoreCard from '~/components/scorecards/WaitTimeScoreCard';
@@ -25,15 +12,15 @@ import FilterPanel from '~/components/FilterPanel';
 import CONFIG from '~/config';
 import LineComparison from '~/components/LineComparison';
 
-const styles = theme => ({
+const styles = () => ({
   cardImage: {
     width: '100%',
   },
   container: {
   },
   item: {
-    height: 400
-  }
+    height: 400,
+  },
 });
 
 class Index extends Component {
@@ -42,14 +29,14 @@ class Index extends Component {
     this.state = {
       currentLine: 'All',
       arrivalWindow: '1_min',
-      date: 'Today'
+      date: 'Today',
     };
     this.handleLineChange = this.handleLineChange.bind(this);
     this.handleArrivalWindow = this.handleArrivalWindow.bind(this);
     this.handleDate = this.handleDate.bind(this);
   }
 
-  static async getInitialProps({ query, res }) {
+  static async getInitialProps({ query }) {
     const { data } = await axios.get(`${CONFIG.RAILSTATS_API}/history`);
     const formattedLineData = Object.values(data[0]);
     const allLineData = data[1];
@@ -72,22 +59,24 @@ class Index extends Component {
   }
 
   render() {
-    const { classes,  formattedLineData, allLineData, width } = this.props;
+    const {
+      classes, formattedLineData, allLineData, width,
+    } = this.props;
     const { currentLine, arrivalWindow, date } = this.state;
-    const data = date === 'Yesterday' ?
-      allLineData[allLineData.length - 2] :
-      allLineData[allLineData.length - 1];
-    const timestamp = data.timestamp
+    const data = date === 'Yesterday'
+      ? allLineData[allLineData.length - 2]
+      : allLineData[allLineData.length - 1];
+    const { timestamp } = data;
 
     return (
       <Layout
         pageTitle="Network Summary"
         toolbarTitle="Network Summary"
       >
-        <Grid container spacing={24} justify="space-around" className={ classes.container }>
-          <Grid container item xs={12} md={8} justify="center" alignItems="center" className={ classes.container }>
+        <Grid container spacing={24} justify="space-around" className={classes.container}>
+          <Grid container item xs={12} md={8} justify="center" alignItems="center" className={classes.container}>
             <LogoAndTitle
-              timestamp={ timestamp }
+              timestamp={timestamp}
               line={currentLine}
               date={date}
               altImg="/static/images/logo_network.svg"
@@ -104,23 +93,34 @@ class Index extends Component {
           >
             <Grid item xs={12} md={2}>
               <FilterPanel
-                line={ currentLine }
-                handleLineChange={ this.handleLineChange }
-                arrivalWindow={ arrivalWindow }
-                handleArrivalWindow={ this.handleArrivalWindow }
-                date={ date }
-                dates={["Today", "Yesterday"]}
-                handleDate={ this.handleDate }
+                line={currentLine}
+                handleLineChange={this.handleLineChange}
+                arrivalWindow={arrivalWindow}
+                handleArrivalWindow={this.handleArrivalWindow}
+                date={date}
+                dates={['Today', 'Yesterday']}
+                handleDate={this.handleDate}
               />
             </Grid>
-            <Grid item xs={12} md={5} classes={ classes }>
-              <PerformanceScoreCard data={ data } width={ width } currentLine={currentLine} arrivalWindow={arrivalWindow} formattedLineData={formattedLineData} />
+            <Grid item xs={12} md={5} classes={classes}>
+              <PerformanceScoreCard
+                data={data}
+                width={width}
+                currentLine={currentLine}
+                arrivalWindow={arrivalWindow}
+                formattedLineData={formattedLineData}
+              />
             </Grid>
-            <Grid item xs={12} md={5} classes={ classes }>
-              <WaitTimeScoreCard width={width} data={ data }  currentLine={currentLine} formattedLineData={formattedLineData} />
+            <Grid item xs={12} md={5} classes={classes}>
+              <WaitTimeScoreCard
+                width={width}
+                data={data}
+                currentLine={currentLine}
+                formattedLineData={formattedLineData}
+              />
             </Grid>
             <Grid item xs={12} md={12}>
-              <LineComparison formattedData={formattedLineData} allLineData={allLineData}/>
+              <LineComparison formattedData={formattedLineData} allLineData={allLineData} />
             </Grid>
           </Grid>
         </Grid>

--- a/pages/index/index.jsx
+++ b/pages/index/index.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import axios from 'axios';
 import { Grid } from '@material-ui/core';
 import { withStyles } from '@material-ui/core/styles';
@@ -128,5 +129,20 @@ class Index extends Component {
     );
   }
 }
+
+Index.defaultProps = {
+  width: 'lg',
+  classes: {},
+  formattedLineData: [],
+  allLineData: [],
+};
+
+Index.propTypes = {
+  classes: PropTypes.object,
+  formattedLineData: PropTypes.arrayOf(PropTypes.object),
+  allLineData: PropTypes.arrayOf(PropTypes.object),
+  width: PropTypes.string,
+};
+
 
 export default flowRight([withStyles(styles), withWidth()])(Index);

--- a/pages/index/index.jsx
+++ b/pages/index/index.jsx
@@ -14,11 +14,6 @@ import CONFIG from '~/config';
 import LineComparison from '~/components/LineComparison';
 
 const styles = () => ({
-  cardImage: {
-    width: '100%',
-  },
-  container: {
-  },
   item: {
     height: 400,
   },
@@ -90,7 +85,7 @@ class Index extends Component {
             xs={12}
             lg={9}
             justify="space-between"
-            alignItems="top"
+            alignItems="flex-start"
           >
             <Grid item xs={12} md={2}>
               <FilterPanel

--- a/pages/line/TrainDetails.jsx
+++ b/pages/line/TrainDetails.jsx
@@ -1,11 +1,10 @@
 import React, { Component } from 'react';
-import { Typography, Grid, Toolbar, Paper, Divider } from '@material-ui/core';
-import Highchart from '~/components/charts/Highchart';
+import { Grid, Toolbar } from '@material-ui/core';
 import DataParser from '~/components/DataParser';
 import { withStyles } from '@material-ui/core/styles';
 import SimpleMenu from '~/components/SimpleMenu';
 import directionNames from '~/helpers/Directions.js';
-import { whenGotS3Object, whenListAllObjects } from '~/helpers/DataFinder.js';
+import { whenListAllObjects } from '~/helpers/DataFinder.js';
 
 const styles = theme => ({
   paper: {
@@ -15,13 +14,13 @@ const styles = theme => ({
     color: theme.palette.text.secondary,
   },
   root: {
-    margin: '20px 0'
+    margin: '20px 0',
   },
   optionsBar: {
     display: 'flex',
     flexDirection: 'row',
     justifyContent: 'space-between',
-  }
+  },
 });
 
 class TrainDetails extends Component {
@@ -30,7 +29,7 @@ class TrainDetails extends Component {
     this.state = {
       direction: 0,
       date: props.date,
-      availableDates: [props.date]
+      availableDates: [props.date],
     };
     this.handleDirectionChange = this.handleDirectionChange.bind(this);
     this.populateDates = this.populateDates.bind(this);
@@ -38,16 +37,19 @@ class TrainDetails extends Component {
   }
 
   componentDidMount() {
-    const listParams = {Bucket: 'h4la-metro-performance', Prefix: `data/schedule/${this.props.line}_lametro-rail`};
+    const { line } = this.props;
+    const listParams = {
+      Bucket: 'h4la-metro-performance',
+      Prefix: `data/schedule/${line}_lametro-rail`
+    };
     whenListAllObjects(listParams).then(this.populateDates);
   }
 
   populateDates(datePaths) {
-    const prefix = `data/schedule/${this.props.line}_lametro-rail/`;
+    const { line } = this.props;
+    const prefix = `data/schedule/${line}_lametro-rail/`;
     const myRegexp = new RegExp(`${prefix}(.*).csv`);
-    const formattedDates = datePaths.reverse().map((path) => {
-      return myRegexp.exec(path)[1]
-    });
+    const formattedDates = datePaths.reverse().map(path => myRegexp.exec(path)[1]);
     this.setState({ availableDates: formattedDates });
   }
 
@@ -56,26 +58,27 @@ class TrainDetails extends Component {
   }
 
   changeDate(newDate) {
-    this.setState({ date: newDate })
+    this.setState({ date: newDate });
   }
 
   render() {
-    const { classes } = this.props;
-    const directions = [directionNames[`${this.props.line}_0`], directionNames[`${this.props.line}_1`]];
+    const { classes, line } = this.props;
+    const { direction, availableDates, date } = this.state;
+    const directions = [directionNames[`${line}_0`], directionNames[`${line}_1`]];
 
     return (
       <Grid container justify="center" spacing={24}>
         <Grid item xs={12}>
-          <Toolbar color="primary" className={ classes.optionsBar }>
-            <SimpleMenu label={`Towards: ${directions[this.state.direction]}`} menuItems={directions} handleMenuChange={ this.handleDirectionChange } />
-            <SimpleMenu label={`Select Date: ${this.state.date}`} menuItems={this.state.availableDates} handleMenuChange={ this.changeDate } />
+          <Toolbar color="primary" className={classes.optionsBar}>
+            <SimpleMenu label={`Towards: ${directions[direction]}`} menuItems={directions} handleMenuChange={this.handleDirectionChange} />
+            <SimpleMenu label={`Select Date: ${date}`} menuItems={availableDates} handleMenuChange={this.changeDate} />
           </Toolbar>
         </Grid>
         <Grid item xs={12}>
-          <DataParser line={ this.props.line } direction={ this.state.direction } date={this.state.date}/>
+          <DataParser line={line} direction={direction} date={date} />
         </Grid>
       </Grid>
-    )
+    );
   }
 }
 

--- a/pages/line/TrainDetails.jsx
+++ b/pages/line/TrainDetails.jsx
@@ -1,10 +1,11 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import { Grid, Toolbar } from '@material-ui/core';
 import DataParser from '~/components/DataParser';
 import { withStyles } from '@material-ui/core/styles';
 import SimpleMenu from '~/components/SimpleMenu';
-import directionNames from '~/helpers/Directions.js';
-import { whenListAllObjects } from '~/helpers/DataFinder.js';
+import directionNames from '~/helpers/Directions';
+import { whenListAllObjects } from '~/helpers/DataFinder';
 
 const styles = theme => ({
   paper: {
@@ -26,10 +27,11 @@ const styles = theme => ({
 class TrainDetails extends Component {
   constructor(props) {
     super(props);
+    const { date } = props;
     this.state = {
       direction: 0,
-      date: props.date,
-      availableDates: [props.date],
+      date,
+      availableDates: [date],
     };
     this.handleDirectionChange = this.handleDirectionChange.bind(this);
     this.populateDates = this.populateDates.bind(this);
@@ -40,7 +42,7 @@ class TrainDetails extends Component {
     const { line } = this.props;
     const listParams = {
       Bucket: 'h4la-metro-performance',
-      Prefix: `data/schedule/${line}_lametro-rail`
+      Prefix: `data/schedule/${line}_lametro-rail`,
     };
     whenListAllObjects(listParams).then(this.populateDates);
   }
@@ -81,5 +83,15 @@ class TrainDetails extends Component {
     );
   }
 }
+
+TrainDetails.defaultProps = {
+  classes: {},
+};
+
+TrainDetails.propTypes = {
+  date: PropTypes.string.isRequired,
+  classes: PropTypes.object,
+  line: PropTypes.number.isRequired,
+};
 
 export default withStyles(styles)(TrainDetails);

--- a/pages/line/TrainStats.jsx
+++ b/pages/line/TrainStats.jsx
@@ -1,4 +1,6 @@
-import React, { Component, Fragment } from 'react';
+import React, { Fragment } from 'react';
+import PropTypes from 'prop-types';
+import LinePropType from '~/models/LinePropType';
 import {
   Grid,
   Hidden,
@@ -24,7 +26,7 @@ const TrainStats = (props) => {
     data,
     switchTab,
     line,
-    width
+    width,
   } = props;
   return (
     <Fragment>
@@ -55,6 +57,19 @@ const TrainStats = (props) => {
       </Grid>
     </Fragment>
   );
+};
+
+TrainStats.defaultProps = {
+  classes: {},
+  width: 'lg',
+};
+
+TrainStats.propTypes = {
+  classes: PropTypes.object,
+  data: LinePropType.isRequired,
+  switchTab: PropTypes.func.isRequired,
+  line: PropTypes.number.isRequired,
+  width: PropTypes.string,
 };
 
 export default flowRight([withStyles(styles), withWidth()])(TrainStats);

--- a/pages/line/TrainStats.jsx
+++ b/pages/line/TrainStats.jsx
@@ -1,9 +1,9 @@
-import React, {Component, Fragment} from 'react';
+import React, { Component, Fragment } from 'react';
 import {
   Grid,
-  Hidden
+  Hidden,
 } from '@material-ui/core';
-import {withStyles} from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/core/styles';
 import withWidth from '@material-ui/core/withWidth';
 import flowRight from 'lodash/flowRight';
 import LogoAndTitle from '~/components/LogoAndTitle';
@@ -12,35 +12,39 @@ import WaitTimeScoreCard from '~/components/scorecards/WaitTimeScoreCard';
 import LineSelector from '~/components/LineSelector';
 import DiagramLink from '~/components/DiagramLink';
 
-const styles = theme => ({
+const styles = () => ({
   spaceTop: {
-    marginTop: '1em'
-  }
+    marginTop: '1em',
+  },
 });
 
 const TrainStats = (props) => {
-  const {classes} = props;
-  const data = props.data;
-  const switchTab = props.switchTab;
+  const {
+    classes,
+    data,
+    switchTab,
+    line,
+    width
+  } = props;
   return (
     <Fragment>
       <Grid container spacing={24} justify="space-around">
         <Grid container item xs={12} md={8} justify="center" alignItems="center">
           <Grid item xs={12}>
-            <LogoAndTitle line={props.line} timestamp={ data.timestamp }/>
+            <LogoAndTitle line={line} timestamp={data.timestamp} />
           </Grid>
         </Grid>
         <Grid container item spacing={16} xs={12} lg={8} justify="space-between" alignItems="center">
           <Grid item xs={12} md={6}>
-            <PerformanceScoreCard data={ data } width={ props.width } />
+            <PerformanceScoreCard data={data} width={width} />
           </Grid>
           <Grid container item xs={12} md={5}>
             <Grid item xs={12}>
-              <WaitTimeScoreCard width={props.width} data={ data }/>
+              <WaitTimeScoreCard width={width} data={data} />
             </Grid>
             <Hidden smDown>
-              <Grid item xs={12} className={ classes.spaceTop }>
-                <DiagramLink action={ switchTab } line={ props.line }/>
+              <Grid item xs={12} className={classes.spaceTop}>
+                <DiagramLink action={switchTab} line={line} />
               </Grid>
             </Hidden>
           </Grid>
@@ -50,7 +54,7 @@ const TrainStats = (props) => {
         </Grid>
       </Grid>
     </Fragment>
-  )
-}
+  );
+};
 
 export default flowRight([withStyles(styles), withWidth()])(TrainStats);

--- a/pages/line/index.jsx
+++ b/pages/line/index.jsx
@@ -1,11 +1,12 @@
 import React, { Component } from 'react';
 import axios from 'axios';
 import PropTypes from 'prop-types';
+import LinePropType from '~/models/LinePropType';
 import { Hidden, Tab, Tabs } from '@material-ui/core';
 import Layout from '~/components/Layout';
 import TrainDetails from './TrainDetails';
 import TrainStats from './TrainStats';
-import { linesById } from '~/helpers/LineInfo.js';
+import { linesById } from '~/helpers/LineInfo';
 import CONFIG from '~/config';
 
 class Line extends Component {
@@ -81,9 +82,15 @@ Line
 }
 
 Line.defaultProps = {
-  id: 9,
+  data: {},
+  query: { id: 801 },
 };
+
 Line.propTypes = {
-  id: PropTypes.number,
+  query: PropTypes.shape({
+    id: PropTypes.number,
+  }),
+  data: LinePropType,
 };
+
 export default Line;

--- a/pages/line/index.jsx
+++ b/pages/line/index.jsx
@@ -6,11 +6,7 @@ import Layout from '~/components/Layout';
 import TrainDetails from './TrainDetails';
 import TrainStats from './TrainStats';
 import { linesById } from '~/helpers/LineInfo.js';
-import { whenGotS3Object, whenListAllObjects } from '~/helpers/DataFinder.js';
 import CONFIG from '~/config';
-
-import S3 from 'aws-sdk/clients/s3';
-const s3 = new S3();
 
 class Line extends Component {
   constructor(props) {
@@ -20,7 +16,7 @@ class Line extends Component {
     };
   }
 
-  static async getInitialProps({ query, res }) {
+  static async getInitialProps({ query }) {
     const { data } = await axios.get(`${CONFIG.RAILSTATS_API}/line/${query.id}`);
     return { query, data };
   }
@@ -30,12 +26,12 @@ class Line extends Component {
   };
 
   handleTabChange = (event, newValue) => {
-    this.setState(state => ({ selectedTab: newValue }));
+    this.setState({ selectedTab: newValue });
   };
 
   render() {
-    const { id } = this.props.query;
-    const { data } = this.props;
+    const { data, query } = this.props;
+    const { id } = query;
     const { selectedTab } = this.state;
     const switchTab = this.handleTabChange;
     const toolbarChildren = (
@@ -46,10 +42,14 @@ class Line extends Component {
         </Tabs>
       </Hidden>
     );
-    const pageTitle = `${ linesById[id].name } Line`;
+    const pageTitle = `${linesById[id].name} Line`;
     const toolbarTitle = (
       <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
-        Metro { linesById[id].name } Line
+        Metro
+        {' '}
+        { linesById[id].name }
+        {' '}
+Line
         <div
           style={{
             backgroundColor: linesById[id].color,
@@ -67,9 +67,14 @@ class Line extends Component {
     );
 
     return (
-      <Layout style={{ minHeight: '100%' }} pageTitle={pageTitle} toolbarTitle={toolbarTitle} toolbarChildren={toolbarChildren}>
-        {selectedTab === 0 && <TrainStats line={id} data={data} switchTab={ switchTab }/>}
-        {selectedTab === 1 && <TrainDetails line={id} date={data["date"]} />}
+      <Layout
+        style={{ minHeight: '100%' }}
+        pageTitle={pageTitle}
+        toolbarTitle={toolbarTitle}
+        toolbarChildren={toolbarChildren}
+      >
+        {selectedTab === 0 && <TrainStats line={id} data={data} switchTab={switchTab} />}
+        {selectedTab === 1 && <TrainDetails line={id} date={data.date} />}
       </Layout>
     );
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -687,6 +687,13 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
+"@babel/runtime@^7.3.1":
+  version "7.4.5"
+  resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.5.tgz#582bb531f5f9dc67d2fcb682979894f75e253f12"
+  integrity sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/template@7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0.tgz#c2bc9870405959c89a9c814376a2ecb247838c80"
@@ -729,55 +736,6 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
-"@mapbox/geojson-area@0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@mapbox/geojson-area/-/geojson-area-0.2.2.tgz#18d7814aa36bf23fbbcc379f8e26a22927debf10"
-  integrity sha1-GNeBSqNr8j+7zDefjiaiKSfevxA=
-  dependencies:
-    wgs84 "0.0.0"
-
-"@mapbox/geojson-types@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@mapbox/geojson-types/-/geojson-types-1.0.2.tgz#9aecf642cb00eab1080a57c4f949a65b4a5846d6"
-  integrity sha512-e9EBqHHv3EORHrSfbR9DqecPNn+AmuAoQxV6aL8Xu30bJMJR1o8PZLZzpk1Wq7/NfCbuhmakHTPYRhoqLsXRnw==
-
-"@mapbox/jsonlint-lines-primitives@^2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz#ce56e539f83552b58d10d672ea4d6fc9adc7b234"
-  integrity sha1-zlblOfg1UrWNENZy6k1vya3HsjQ=
-
-"@mapbox/mapbox-gl-supported@^1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.4.0.tgz#36946b22944fe2cfa43cfafd5ef36fdb54a069e4"
-  integrity sha512-ZD0Io4XK+/vU/4zpANjOtdWfVszAgnaMPsGR6LKsWh4kLIEv9qoobTVmJPPuwuM+ZI2b3BlZ6DYw1XHVmv6YTA==
-
-"@mapbox/point-geometry@0.1.0", "@mapbox/point-geometry@^0.1.0", "@mapbox/point-geometry@~0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz#8a83f9335c7860effa2eeeca254332aa0aeed8f2"
-  integrity sha1-ioP5M1x4YO/6Lu7KJUMyqgru2PI=
-
-"@mapbox/tiny-sdf@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@mapbox/tiny-sdf/-/tiny-sdf-1.1.0.tgz#b0b8f5c22005e6ddb838f421ffd257c1f74f9a20"
-  integrity sha512-dnhyk8X2BkDRWImgHILYAGgo+kuciNYX30CUKj/Qd5eNjh54OWM/mdOS/PWsPeN+3abtN+QDGYM4G220ynVJKA==
-
-"@mapbox/unitbezier@^0.0.0":
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz#15651bd553a67b8581fb398810c98ad86a34524e"
-  integrity sha1-FWUb1VOme4WB+zmIEMmK2Go0Uk4=
-
-"@mapbox/vector-tile@^1.3.1":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz#d3a74c90402d06e89ec66de49ec817ff53409666"
-  integrity sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==
-  dependencies:
-    "@mapbox/point-geometry" "~0.1.0"
-
-"@mapbox/whoots-js@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz#497c67a1cef50d1a2459ba60f315e448d2ad87fe"
-  integrity sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==
-
 "@material-ui/core@^3.8.3":
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-3.9.0.tgz#7e74cf1979ee65f9fd388145764b3e58f48da6c6"
@@ -819,6 +777,17 @@
   dependencies:
     "@babel/runtime" "^7.2.0"
     recompose "0.28.0 - 0.30.0"
+
+"@material-ui/lab@^3.0.0-alpha.30":
+  version "3.0.0-alpha.30"
+  resolved "https://registry.npmjs.org/@material-ui/lab/-/lab-3.0.0-alpha.30.tgz#c6c64d0ff2b28410a09e4009f3677499461f3df8"
+  integrity sha512-d8IXbkQO92Ln7f/Tzy8Q5cLi/sMWH/Uz1xrOO5NKUgg42whwyCuoT9ErddDPFNQmPi9d1C7A5AG8ONjEAbAIyQ==
+  dependencies:
+    "@babel/runtime" "^7.2.0"
+    "@material-ui/utils" "^3.0.0-alpha.2"
+    classnames "^2.2.5"
+    keycode "^2.1.9"
+    prop-types "^15.6.0"
 
 "@material-ui/system@^3.0.0-alpha.0":
   version "3.0.0-alpha.1"
@@ -1137,11 +1106,6 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
-ansicolors@~0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/ansicolors/-/ansicolors-0.2.1.tgz#be089599097b74a5c9c4a84a0cdbcdb62bd87aef"
-  integrity sha1-vgiVmQl7dKXJxKhKDNvNtivYeu8=
-
 any-promise@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
@@ -1322,6 +1286,21 @@ autodll-webpack-plugin@0.4.2:
     webpack-merge "^4.1.0"
     webpack-sources "^1.0.1"
 
+aws-sdk@^2.404.0:
+  version "2.470.0"
+  resolved "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.470.0.tgz#33cbf793b4ab6a08770e8af90fbf45d517526e7e"
+  integrity sha512-XCMLSNiYaUUc3wxH3NxFxPPmYAF95IHhDwc0o6pOIY30om83ZYJwuPizgheRWXuOGjrXQxWgT6W3EfyfeuAISA==
+  dependencies:
+    buffer "4.9.1"
+    events "1.1.1"
+    ieee754 "1.1.8"
+    jmespath "0.15.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.3.2"
+    xml2js "0.4.19"
+
 axios@^0.18.0:
   version "0.18.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.0.tgz#32d53e4851efdc0a11993b6cd000789d70c05102"
@@ -1363,6 +1342,111 @@ babel-eslint@^10.0.1:
     eslint-scope "3.7.1"
     eslint-visitor-keys "^1.0.0"
 
+babel-helper-builder-binary-assignment-operator-visitor@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz#cce4517ada356f4220bcae8a02c2b346f9a56664"
+  integrity sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=
+  dependencies:
+    babel-helper-explode-assignable-expression "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
+
+babel-helper-call-delegate@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz#ece6aacddc76e41c3461f88bfc575bd0daa2df8d"
+  integrity sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=
+  dependencies:
+    babel-helper-hoist-variables "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+
+babel-helper-define-map@^6.24.1:
+  version "6.26.0"
+  resolved "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz#a5f56dab41a25f97ecb498c7ebaca9819f95be5f"
+  integrity sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=
+  dependencies:
+    babel-helper-function-name "^6.24.1"
+    babel-runtime "^6.26.0"
+    babel-types "^6.26.0"
+    lodash "^4.17.4"
+
+babel-helper-explode-assignable-expression@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz#f25b82cf7dc10433c55f70592d5746400ac22caa"
+  integrity sha1-8luCz33BBDPFX3BZLVdGQArCLKo=
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+
+babel-helper-function-name@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz#d3475b8c03ed98242a25b48351ab18399d3580a9"
+  integrity sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=
+  dependencies:
+    babel-helper-get-function-arity "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+
+babel-helper-get-function-arity@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz#8f7782aa93407c41d3aa50908f89b031b1b6853d"
+  integrity sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
+
+babel-helper-hoist-variables@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz#1ecb27689c9d25513eadbc9914a73f5408be7a76"
+  integrity sha1-HssnaJydJVE+rbyZFKc/VAi+enY=
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
+
+babel-helper-optimise-call-expression@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz#f7a13427ba9f73f8f4fa993c54a97882d1244257"
+  integrity sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
+
+babel-helper-regex@^6.24.1:
+  version "6.26.0"
+  resolved "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz#325c59f902f82f24b74faceed0363954f6495e72"
+  integrity sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=
+  dependencies:
+    babel-runtime "^6.26.0"
+    babel-types "^6.26.0"
+    lodash "^4.17.4"
+
+babel-helper-remap-async-to-generator@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz#5ec581827ad723fecdd381f1c928390676e4551b"
+  integrity sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=
+  dependencies:
+    babel-helper-function-name "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+
+babel-helper-replace-supers@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz#bf6dbfe43938d17369a213ca8a8bf74b6a90ab1a"
+  integrity sha1-v22/5Dk40XNpohPKiov3S2qQqxo=
+  dependencies:
+    babel-helper-optimise-call-expression "^6.24.1"
+    babel-messages "^6.23.0"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+
 babel-loader@8.0.2:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.0.2.tgz#2079b8ec1628284a929241da3d90f5b3de2a5ae5"
@@ -1373,20 +1457,279 @@ babel-loader@8.0.2:
     mkdirp "^0.5.1"
     util.promisify "^1.0.0"
 
+babel-messages@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
+  integrity sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-check-es2015-constants@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz#35157b101426fd2ffd3da3f75c7d1e91835bbf8a"
+  integrity sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=
+  dependencies:
+    babel-runtime "^6.22.0"
+
 babel-plugin-react-require@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-react-require/-/babel-plugin-react-require-3.0.0.tgz#2e4e7b4496b93a654a1c80042276de4e4eeb20e3"
   integrity sha1-Lk57RJa5OmVKHIAEInbeTk7rIOM=
+
+babel-plugin-root-import@^6.1.0:
+  version "6.2.0"
+  resolved "https://registry.npmjs.org/babel-plugin-root-import/-/babel-plugin-root-import-6.2.0.tgz#5a5cbcefbd67506738679ed6f899c013142bcd49"
+  integrity sha512-Tsq1pfSRn2XkNOrMXOYoTAxYddvWC21850h8Cj6xozccwr50WQu+GrzrHmr9RAmHCaLVUOfFYe3cshpQbDmf4w==
+  dependencies:
+    slash "^1.0.0"
+
+babel-plugin-syntax-async-functions@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
+  integrity sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=
+
+babel-plugin-syntax-exponentiation-operator@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de"
+  integrity sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4=
 
 babel-plugin-syntax-jsx@6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
   integrity sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=
 
+babel-plugin-syntax-trailing-function-commas@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz#ba0360937f8d06e40180a43fe0d5616fff532cf3"
+  integrity sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM=
+
+babel-plugin-transform-async-to-generator@^6.22.0:
+  version "6.24.1"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz#6536e378aff6cb1d5517ac0e40eb3e9fc8d08761"
+  integrity sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=
+  dependencies:
+    babel-helper-remap-async-to-generator "^6.24.1"
+    babel-plugin-syntax-async-functions "^6.8.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-arrow-functions@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz#452692cb711d5f79dc7f85e440ce41b9f244d221"
+  integrity sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-block-scoped-functions@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz#bbc51b49f964d70cb8d8e0b94e820246ce3a6141"
+  integrity sha1-u8UbSflk1wy42OC5ToICRs46YUE=
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-block-scoping@^6.23.0:
+  version "6.26.0"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz#d70f5299c1308d05c12f463813b0a09e73b1895f"
+  integrity sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=
+  dependencies:
+    babel-runtime "^6.26.0"
+    babel-template "^6.26.0"
+    babel-traverse "^6.26.0"
+    babel-types "^6.26.0"
+    lodash "^4.17.4"
+
+babel-plugin-transform-es2015-classes@^6.23.0:
+  version "6.24.1"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz#5a4c58a50c9c9461e564b4b2a3bfabc97a2584db"
+  integrity sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=
+  dependencies:
+    babel-helper-define-map "^6.24.1"
+    babel-helper-function-name "^6.24.1"
+    babel-helper-optimise-call-expression "^6.24.1"
+    babel-helper-replace-supers "^6.24.1"
+    babel-messages "^6.23.0"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+
+babel-plugin-transform-es2015-computed-properties@^6.22.0:
+  version "6.24.1"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz#6fe2a8d16895d5634f4cd999b6d3480a308159b3"
+  integrity sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+
+babel-plugin-transform-es2015-destructuring@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz#997bb1f1ab967f682d2b0876fe358d60e765c56d"
+  integrity sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-duplicate-keys@^6.22.0:
+  version "6.24.1"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz#73eb3d310ca969e3ef9ec91c53741a6f1576423e"
+  integrity sha1-c+s9MQypaePvnskcU3QabxV2Qj4=
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
+
+babel-plugin-transform-es2015-for-of@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz#f47c95b2b613df1d3ecc2fdb7573623c75248691"
+  integrity sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-function-name@^6.22.0:
+  version "6.24.1"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz#834c89853bc36b1af0f3a4c5dbaa94fd8eacaa8b"
+  integrity sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=
+  dependencies:
+    babel-helper-function-name "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
+
+babel-plugin-transform-es2015-literals@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz#4f54a02d6cd66cf915280019a31d31925377ca2e"
+  integrity sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-modules-amd@^6.22.0, babel-plugin-transform-es2015-modules-amd@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz#3b3e54017239842d6d19c3011c4bd2f00a00d154"
+  integrity sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=
+  dependencies:
+    babel-plugin-transform-es2015-modules-commonjs "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+
+babel-plugin-transform-es2015-modules-commonjs@^6.23.0, babel-plugin-transform-es2015-modules-commonjs@^6.24.1:
+  version "6.26.2"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz#58a793863a9e7ca870bdc5a881117ffac27db6f3"
+  integrity sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==
+  dependencies:
+    babel-plugin-transform-strict-mode "^6.24.1"
+    babel-runtime "^6.26.0"
+    babel-template "^6.26.0"
+    babel-types "^6.26.0"
+
+babel-plugin-transform-es2015-modules-systemjs@^6.23.0:
+  version "6.24.1"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz#ff89a142b9119a906195f5f106ecf305d9407d23"
+  integrity sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=
+  dependencies:
+    babel-helper-hoist-variables "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+
+babel-plugin-transform-es2015-modules-umd@^6.23.0:
+  version "6.24.1"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz#ac997e6285cd18ed6176adb607d602344ad38468"
+  integrity sha1-rJl+YoXNGO1hdq22B9YCNErThGg=
+  dependencies:
+    babel-plugin-transform-es2015-modules-amd "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+
+babel-plugin-transform-es2015-object-super@^6.22.0:
+  version "6.24.1"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz#24cef69ae21cb83a7f8603dad021f572eb278f8d"
+  integrity sha1-JM72muIcuDp/hgPa0CH1cusnj40=
+  dependencies:
+    babel-helper-replace-supers "^6.24.1"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-parameters@^6.23.0:
+  version "6.24.1"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz#57ac351ab49caf14a97cd13b09f66fdf0a625f2b"
+  integrity sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=
+  dependencies:
+    babel-helper-call-delegate "^6.24.1"
+    babel-helper-get-function-arity "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+
+babel-plugin-transform-es2015-shorthand-properties@^6.22.0:
+  version "6.24.1"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz#24f875d6721c87661bbd99a4622e51f14de38aa0"
+  integrity sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
+
+babel-plugin-transform-es2015-spread@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz#d6d68a99f89aedc4536c81a542e8dd9f1746f8d1"
+  integrity sha1-1taKmfia7cRTbIGlQujdnxdG+NE=
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-sticky-regex@^6.22.0:
+  version "6.24.1"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz#00c1cdb1aca71112cdf0cf6126c2ed6b457ccdbc"
+  integrity sha1-AMHNsaynERLN8M9hJsLta0V8zbw=
+  dependencies:
+    babel-helper-regex "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
+
+babel-plugin-transform-es2015-template-literals@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz#a84b3450f7e9f8f1f6839d6d687da84bb1236d8d"
+  integrity sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-typeof-symbol@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz#dec09f1cddff94b52ac73d505c84df59dcceb372"
+  integrity sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-es2015-unicode-regex@^6.22.0:
+  version "6.24.1"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz#d38b12f42ea7323f729387f18a7c5ae1faeb35e9"
+  integrity sha1-04sS9C6nMj9yk4fxinxa4frrNek=
+  dependencies:
+    babel-helper-regex "^6.24.1"
+    babel-runtime "^6.22.0"
+    regexpu-core "^2.0.0"
+
+babel-plugin-transform-exponentiation-operator@^6.22.0:
+  version "6.24.1"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz#2ab0c9c7f3098fa48907772bb813fe41e8de3a0e"
+  integrity sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=
+  dependencies:
+    babel-helper-builder-binary-assignment-operator-visitor "^6.24.1"
+    babel-plugin-syntax-exponentiation-operator "^6.8.0"
+    babel-runtime "^6.22.0"
+
 babel-plugin-transform-react-remove-prop-types@0.4.15:
   version "0.4.15"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.15.tgz#7ba830e77276a0e788cd58ea527b5f70396e12a7"
   integrity sha512-bFxxYdkZBwTjTgtZEPTLqu9g8Ajz8x8uEP/O1iVuaZIz2RuxJ2gtx0EXDJRonC++KGsgsW/4Hqvk4KViEtE2nw==
+
+babel-plugin-transform-regenerator@^6.22.0:
+  version "6.26.0"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz#e0703696fbde27f0a3efcacf8b4dca2f7b3a8f2f"
+  integrity sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=
+  dependencies:
+    regenerator-transform "^0.10.0"
+
+babel-plugin-transform-strict-mode@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz#d5faf7aa578a65bbe591cf5edae04a0c67020758"
+  integrity sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
 
 babel-polyfill@^6.26.0:
   version "6.26.0"
@@ -1397,7 +1740,43 @@ babel-polyfill@^6.26.0:
     core-js "^2.5.0"
     regenerator-runtime "^0.10.5"
 
-babel-runtime@^6.26.0:
+babel-preset-env@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz#dea79fa4ebeb883cd35dab07e260c1c9c04df77a"
+  integrity sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==
+  dependencies:
+    babel-plugin-check-es2015-constants "^6.22.0"
+    babel-plugin-syntax-trailing-function-commas "^6.22.0"
+    babel-plugin-transform-async-to-generator "^6.22.0"
+    babel-plugin-transform-es2015-arrow-functions "^6.22.0"
+    babel-plugin-transform-es2015-block-scoped-functions "^6.22.0"
+    babel-plugin-transform-es2015-block-scoping "^6.23.0"
+    babel-plugin-transform-es2015-classes "^6.23.0"
+    babel-plugin-transform-es2015-computed-properties "^6.22.0"
+    babel-plugin-transform-es2015-destructuring "^6.23.0"
+    babel-plugin-transform-es2015-duplicate-keys "^6.22.0"
+    babel-plugin-transform-es2015-for-of "^6.23.0"
+    babel-plugin-transform-es2015-function-name "^6.22.0"
+    babel-plugin-transform-es2015-literals "^6.22.0"
+    babel-plugin-transform-es2015-modules-amd "^6.22.0"
+    babel-plugin-transform-es2015-modules-commonjs "^6.23.0"
+    babel-plugin-transform-es2015-modules-systemjs "^6.23.0"
+    babel-plugin-transform-es2015-modules-umd "^6.23.0"
+    babel-plugin-transform-es2015-object-super "^6.22.0"
+    babel-plugin-transform-es2015-parameters "^6.23.0"
+    babel-plugin-transform-es2015-shorthand-properties "^6.22.0"
+    babel-plugin-transform-es2015-spread "^6.22.0"
+    babel-plugin-transform-es2015-sticky-regex "^6.22.0"
+    babel-plugin-transform-es2015-template-literals "^6.22.0"
+    babel-plugin-transform-es2015-typeof-symbol "^6.23.0"
+    babel-plugin-transform-es2015-unicode-regex "^6.22.0"
+    babel-plugin-transform-exponentiation-operator "^6.22.0"
+    babel-plugin-transform-regenerator "^6.22.0"
+    browserslist "^3.2.6"
+    invariant "^2.2.2"
+    semver "^5.3.0"
+
+babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   integrity sha1-llxwWGaOgrVde/4E/yM3vItWR/4=
@@ -1405,15 +1784,46 @@ babel-runtime@^6.26.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
 
-babel-types@6.26.0:
+babel-template@^6.24.1, babel-template@^6.26.0:
   version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
+  resolved "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
+  integrity sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=
+  dependencies:
+    babel-runtime "^6.26.0"
+    babel-traverse "^6.26.0"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
+    lodash "^4.17.4"
+
+babel-traverse@^6.24.1, babel-traverse@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
+  integrity sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=
+  dependencies:
+    babel-code-frame "^6.26.0"
+    babel-messages "^6.23.0"
+    babel-runtime "^6.26.0"
+    babel-types "^6.26.0"
+    babylon "^6.18.0"
+    debug "^2.6.8"
+    globals "^9.18.0"
+    invariant "^2.2.2"
+    lodash "^4.17.4"
+
+babel-types@6.26.0, babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
   integrity sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=
   dependencies:
     babel-runtime "^6.26.0"
     esutils "^2.0.2"
     lodash "^4.17.4"
     to-fast-properties "^1.0.3"
+
+babylon@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
+  integrity sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -1572,6 +1982,14 @@ browserify-zlib@^0.2.0:
   dependencies:
     pako "~1.0.5"
 
+browserslist@^3.2.6:
+  version "3.2.8"
+  resolved "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz#b0005361d6471f0f5952797a76fc985f1f978fc6"
+  integrity sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==
+  dependencies:
+    caniuse-lite "^1.0.30000844"
+    electron-to-chromium "^1.3.47"
+
 browserslist@^4.1.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.4.0.tgz#7050d1412cbfc5274aba609ed5e50359ca1a5fdf"
@@ -1591,9 +2009,9 @@ buffer-xor@^1.0.3:
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
   integrity sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=
 
-buffer@^4.3.0:
+buffer@4.9.1, buffer@^4.3.0:
   version "4.9.1"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298"
+  resolved "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298"
   integrity sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=
   dependencies:
     base64-js "^1.0.2"
@@ -1674,18 +2092,15 @@ callsites@^3.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.0.0.tgz#fb7eb569b72ad7a45812f93fd9430a3e410b3dd3"
   integrity sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw==
 
+caniuse-lite@^1.0.30000844:
+  version "1.0.30000974"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000974.tgz#b7afe14ee004e97ce6dc73e3f878290a12928ad8"
+  integrity sha512-xc3rkNS/Zc3CmpMKuczWEdY2sZgx09BkAxfvkxlAEBTqcMHeL8QnPqhKse+5sRTi3nrw2pJwToD2WvKn1Uhvww==
+
 caniuse-lite@^1.0.30000928:
   version "1.0.30000928"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000928.tgz#805e828dc72b06498e3683a32e61c7507fd67b88"
   integrity sha512-aSpMWRXL6ZXNnzm8hgE4QDLibG5pVJ2Ujzsuj3icazlIkxXkPXtL+BWnMx6FBkWmkZgBHGUxPZQvrbRw2ZTxhg==
-
-cardinal@~0.4.2:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/cardinal/-/cardinal-0.4.4.tgz#ca5bb68a5b511b90fe93b9acea49bdee5c32bfe2"
-  integrity sha1-ylu2iltRG5D+k7ms6km97lwyv+I=
-  dependencies:
-    ansicolors "~0.2.1"
-    redeyed "~0.4.0"
 
 case-sensitive-paths-webpack-plugin@2.1.2:
   version "2.1.2"
@@ -1782,7 +2197,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.5:
+classnames@^2.2.5, classnames@^2.2.6:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
@@ -1859,12 +2274,32 @@ component-emitter@^1.2.1:
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
   integrity sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=
 
+compressible@~2.0.16:
+  version "2.0.17"
+  resolved "https://registry.npmjs.org/compressible/-/compressible-2.0.17.tgz#6e8c108a16ad58384a977f3a482ca20bff2f38c1"
+  integrity sha512-BGHeLCK1GV7j1bSmQQAi26X+GgWcTjLr/0tzSvMCl3LH1w1IJ4PFSPoV5316b30cneTziC+B1a+3OjoSUcQYmw==
+  dependencies:
+    mime-db ">= 1.40.0 < 2"
+
+compression@^1.7.3:
+  version "1.7.4"
+  resolved "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz#95523eff170ca57c29a0ca41e6fe131f41e5bb8f"
+  integrity sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==
+  dependencies:
+    accepts "~1.3.5"
+    bytes "3.0.0"
+    compressible "~2.0.16"
+    debug "2.6.9"
+    on-headers "~1.0.2"
+    safe-buffer "5.1.2"
+    vary "~1.1.2"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-concat-stream@^1.5.0, concat-stream@~1.6.0:
+concat-stream@^1.5.0:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   integrity sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==
@@ -2016,6 +2451,15 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+create-react-class@^15.6.0:
+  version "15.6.3"
+  resolved "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.3.tgz#2d73237fb3f970ae6ebe011a9e66f46dbca80036"
+  integrity sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 cross-spawn@5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -2087,11 +2531,6 @@ css-vendor@^0.3.8:
   dependencies:
     is-in-browser "^1.0.2"
 
-csscolorparser@~1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/csscolorparser/-/csscolorparser-1.0.3.tgz#b34f391eea4da8f3e98231e2ccd8df9c041f171b"
-  integrity sha1-s085HupNqPPpgjHizNjfnAQfFxs=
-
 cssesc@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-0.1.0.tgz#c814903e45623371a0477b40109aaafbeeaddbb4"
@@ -2112,14 +2551,14 @@ d3-array@^1.2.0:
   resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.4.tgz#635ce4d5eea759f6f605863dbcfc30edc737f71f"
   integrity sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==
 
-d3-array@^2.0.2:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-2.0.3.tgz#9c0531eda701e416f28a030e3d4e6179ba74f19f"
-  integrity sha512-C7g4aCOoJa+/K5hPVqZLG8wjYHsTUROTk7Z1Ep9F4P5l+WVrvV0+6nAZ1wKTRLMhFWpGbozxUpyjIPZYAaLi+g==
+"d3-array@^1.2.0 || 2":
+  version "2.2.0"
+  resolved "https://registry.npmjs.org/d3-array/-/d3-array-2.2.0.tgz#a9e966b8f8d78f0888d98db1fb840fc8da8ac5c7"
+  integrity sha512-eE0QmSh6xToqM3sxHiJYg/QFdNn52ZEgmFE8A8abU8GsHvsIOolqH8B70/8+VGAKm5MlwaExhqR3DLIjOJMLPA==
 
 d3-axis@^1.0.12:
   version "1.0.12"
-  resolved "https://registry.yarnpkg.com/d3-axis/-/d3-axis-1.0.12.tgz#cdf20ba210cfbb43795af33756886fb3638daac9"
+  resolved "https://registry.npmjs.org/d3-axis/-/d3-axis-1.0.12.tgz#cdf20ba210cfbb43795af33756886fb3638daac9"
   integrity sha512-ejINPfPSNdGFKEOAtnBtdkpr24c4d4jsei6Lg98mxf424ivoDP2956/5HDpIAtmHo85lqT4pruy+zEgvRUBqaQ==
 
 d3-collection@1:
@@ -2146,14 +2585,19 @@ d3-dsv@1, d3-dsv@^1.0.3:
     iconv-lite "0.4"
     rw "1"
 
+d3-ease@^1.0.0:
+  version "1.0.5"
+  resolved "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.5.tgz#8ce59276d81241b1b72042d6af2d40e76d936ffb"
+  integrity sha512-Ct1O//ly5y5lFM9YTdu+ygq7LleSgSE4oj7vUt9tPLHUi8VCV7QoizGpdWRWAwCO9LdYzIrQDg97+hGVdsSGPQ==
+
 d3-format@1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.3.2.tgz#6a96b5e31bcb98122a30863f7d92365c00603562"
   integrity sha512-Z18Dprj96ExragQ0DeGi+SYPQ7pPfRMtUXtsg/ChVIKNBCzjO8XYJvRTC1usblx52lqge56V5ect+frYTQc8WQ==
 
-d3-interpolate@1:
+d3-interpolate@1, d3-interpolate@^1.1.1:
   version "1.3.2"
-  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-1.3.2.tgz#417d3ebdeb4bc4efcc8fd4361c55e4040211fd68"
+  resolved "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.3.2.tgz#417d3ebdeb4bc4efcc8fd4361c55e4040211fd68"
   integrity sha512-NlNKGopqaz9qM1PXh9gBF1KSCVh+jSFErrSlD/4hybwoNX/gt1d8CDbDW+3i+5UOHhjC6s6nMvRxcuoMVNgL2w==
   dependencies:
     d3-color "1"
@@ -2173,27 +2617,39 @@ d3-request@1.0.2:
     d3-dsv "1"
     xmlhttprequest "1"
 
-d3-scale@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-2.1.2.tgz#4e932b7b60182aee9073ede8764c98423e5f9a94"
-  integrity sha512-bESpd64ylaKzCDzvULcmHKZTlzA/6DGSVwx7QSDj/EnX9cpSevsdiwdHFYI9ouo9tNBbV3v5xztHS2uFeOzh8Q==
+d3-scale@^1.0.0:
+  version "1.0.7"
+  resolved "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz#fa90324b3ea8a776422bd0472afab0b252a0945d"
+  integrity sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==
   dependencies:
     d3-array "^1.2.0"
     d3-collection "1"
+    d3-color "1"
     d3-format "1"
     d3-interpolate "1"
     d3-time "1"
     d3-time-format "2"
 
-d3-selection@^1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-1.3.2.tgz#6e70a9df60801c8af28ac24d10072d82cbfdf652"
-  integrity sha512-OoXdv1nZ7h2aKMVg3kaUFbLLK5jXUFAMLD/Tu5JA96mjf8f2a9ZUESGY+C36t8R1WFeWk/e55hy54Ml2I62CRQ==
+d3-scale@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/d3-scale/-/d3-scale-3.0.0.tgz#ddede1278ac3ea2bf3666de6ca625e20bed9b6c9"
+  integrity sha512-ktic5HBFlAZj2CN8CCl/p/JyY8bMQluN7+fA6ICE6yyoMOnSQAZ1Bb8/5LcNpNKMBMJge+5Vv4pWJhARYlQYFw==
+  dependencies:
+    d3-array "^1.2.0 || 2"
+    d3-format "1"
+    d3-interpolate "1"
+    d3-time "1"
+    d3-time-format "2"
 
-d3-shape@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-1.2.2.tgz#f9dba3777a5825f9a8ce8bc928da08c17679e9a7"
-  integrity sha512-hUGEozlKecFZ2bOSNt7ENex+4Tk9uc/m0TtTEHBvitCBxUNjhzm5hS2GrrVRD/ae4IylSmxGeqX5tWC2rASMlQ==
+d3-selection@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.npmjs.org/d3-selection/-/d3-selection-1.4.0.tgz#ab9ac1e664cf967ebf1b479cc07e28ce9908c474"
+  integrity sha512-EYVwBxQGEjLCKF2pJ4+yrErskDnz5v403qvAid96cNdCMr8rmCYfY5RGzWz24mdIbxmDf6/4EAH+K9xperD5jg==
+
+d3-shape@^1.0.0, d3-shape@^1.2.0, d3-shape@^1.3.5:
+  version "1.3.5"
+  resolved "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.5.tgz#e81aea5940f59f0a79cfccac012232a8987c6033"
+  integrity sha512-VKazVR3phgD+MUCldapHD7P9kcrvPcexeX/PkMJmkUov4JM8IxsSg1DvbYoYich9AtdTsa5nNk2++ImPiDiSxg==
   dependencies:
     d3-path "1"
 
@@ -2204,10 +2660,25 @@ d3-time-format@2:
   dependencies:
     d3-time "1"
 
-d3-time@1, d3-time@^1.0.10:
+d3-time@1:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-1.0.10.tgz#8259dd71288d72eeacfd8de281c4bf5c7393053c"
   integrity sha512-hF+NTLCaJHF/JqHN5hE8HVGAXPStEq6/omumPE/SxyHVrR7/qQxusFDo0t0c/44+sCGHthC7yNGFZIEgju0P8g==
+
+d3-time@^1.0.11:
+  version "1.0.11"
+  resolved "https://registry.npmjs.org/d3-time/-/d3-time-1.0.11.tgz#1d831a3e25cd189eb256c17770a666368762bbce"
+  integrity sha512-Z3wpvhPLW4vEScGeIMUckDW7+3hWKOQfAWg/U7PlWBnQmeKQ00gCUsTtWSYulrKNA7ta8hJ+xXc6MHrMuITwEw==
+
+d3-timer@^1.0.0:
+  version "1.0.9"
+  resolved "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.9.tgz#f7bb8c0d597d792ff7131e1c24a36dd471a471ba"
+  integrity sha512-rT34J5HnQUHhcLvhSB9GjCkN0Ddd5Y8nCwDBG2u6wQEeYxT/Lf51fTFFkldeib/sE/J0clIe0pnCfs6g/lRbyg==
+
+d3-voronoi@^1.1.2:
+  version "1.1.4"
+  resolved "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.4.tgz#dd3c78d7653d2bb359284ae478645d95944c8297"
+  integrity sha512-dArJ32hchFsrQ8uMiTBLq256MpnZjeuBtdHpaDlYuQyjU0CVzCJl/BVW+SkszaAeH95D/8gxqAhgx0ouAWAfRg==
 
 damerau-levenshtein@^1.0.4:
   version "1.0.4"
@@ -2419,11 +2890,6 @@ duplexify@^3.4.2, duplexify@^3.6.0:
     readable-stream "^2.0.0"
     stream-shift "^1.0.0"
 
-earcut@^2.1.3:
-  version "2.1.5"
-  resolved "https://registry.yarnpkg.com/earcut/-/earcut-2.1.5.tgz#829280a9a3a0f5fee0529f0a47c3e4eff09b21e4"
-  integrity sha512-QFWC7ywTVLtvRAJTVp8ugsuuGQ5mVqNmJ1cRYeLrSHgP3nycr2RHTJob9OtM0v8ujuoKN0NY1a93J/omeTL1PA==
-
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
@@ -2433,6 +2899,11 @@ electron-to-chromium@^1.3.100:
   version "1.3.103"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.103.tgz#a695777efdbc419cad6cbb0e58458251302cd52f"
   integrity sha512-tObPqGmY9X8MUM8i3MEimYmbnLLf05/QV5gPlkR8MQ3Uj8G8B2govE1U4cQcBYtv3ymck9Y8cIOu4waoiykMZQ==
+
+electron-to-chromium@^1.3.47:
+  version "1.3.150"
+  resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.150.tgz#afb972b53a702b37c76db843c39c967e9f68464b"
+  integrity sha512-5wuYlaXhXbBvavSTij5ZyidICB6sAK/1BwgZZoPCgsniid1oDgzVvDOV/Dw6J25lKV9QZ9ZdQCp8MEfF0/OIKA==
 
 elliptic@^6.0.0:
   version "6.4.1"
@@ -2704,11 +3175,6 @@ eslint@^5.9.0:
     table "^5.0.2"
     text-table "^0.2.0"
 
-esm@^3.0.84:
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/esm/-/esm-3.2.4.tgz#0b728b5d6043061bf552197407bf2c630717812b"
-  integrity sha512-wOuWtQCkkwD1WKQN/k3RsyGSSN+AmiUzdKftn8vaC+uV9JesYmQlODJxgXaaRz0LaaFIlUxZaUu5NPiUAjKAAA==
-
 espree@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/espree/-/espree-5.0.0.tgz#fc7f984b62b36a0f543b13fb9cd7b9f4a7f5b65c"
@@ -2722,11 +3188,6 @@ esprima@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
-
-esprima@~1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/esprima/-/esprima-1.0.4.tgz#9f557e08fc3b4d26ece9dd34f8fbf476b62585ad"
-  integrity sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=
 
 esquery@^1.0.1:
   version "1.0.1"
@@ -2762,9 +3223,9 @@ event-source-polyfill@0.0.12:
   resolved "https://registry.yarnpkg.com/event-source-polyfill/-/event-source-polyfill-0.0.12.tgz#e539cd67fdef2760a16aa5262fa98134df52e3af"
   integrity sha1-5TnNZ/3vJ2ChaqUmL6mBNN9S468=
 
-events@^1.0.0:
+events@1.1.1, events@^1.0.0:
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
+  resolved "https://registry.npmjs.org/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
   integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
 
 evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
@@ -2787,11 +3248,6 @@ expand-brackets@^2.1.4:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
-
-expect.js@~0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/expect.js/-/expect.js-0.2.0.tgz#1028533d2c1c363f74a6796ff57ec0520ded2be1"
-  integrity sha1-EChTPSwcNj90pnlv9X7AUg3tK+E=
 
 express@^4.16.4:
   version "4.16.4"
@@ -2892,7 +3348,7 @@ fastparse@^1.1.1:
   resolved "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.2.tgz#91728c5a5942eced8531283c79441ee4122c35a9"
   integrity sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==
 
-fbjs@^0.8.1:
+fbjs@^0.8.1, fbjs@^0.8.9:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
@@ -3120,6 +3576,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
+fs@0.0.1-security:
+  version "0.0.1-security"
+  resolved "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz#8a7bd37186b6dddf3813f23858b57ecaaf5e41d4"
+  integrity sha1-invTcYa23d84E/I4WLV+yq9eQdQ=
+
 fsevents@^1.2.2:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.6.tgz#d3a1864a71876a2eb9b244e3bd8f606eb09568c0"
@@ -3152,35 +3613,10 @@ gauge@~2.7.3:
     strip-ansi "^3.0.1"
     wide-align "^1.1.0"
 
-geojson-rewind@^0.3.0:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/geojson-rewind/-/geojson-rewind-0.3.1.tgz#22240797c847cc2f0c1d313e4aa0c915afa7f29d"
-  integrity sha1-IiQHl8hHzC8MHTE+SqDJFa+n8p0=
-  dependencies:
-    "@mapbox/geojson-area" "0.2.2"
-    concat-stream "~1.6.0"
-    minimist "1.2.0"
-    sharkdown "^0.1.0"
-
-geojson-vt@^3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/geojson-vt/-/geojson-vt-3.2.1.tgz#f8adb614d2c1d3f6ee7c4265cad4bbf3ad60c8b7"
-  integrity sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg==
-
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
   integrity sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=
-
-gl-matrix@^2.6.1:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/gl-matrix/-/gl-matrix-2.8.1.tgz#1c7873448eac61d2cd25803a074e837bd42581a3"
-  integrity sha512-0YCjVpE3pS5XWlN3J4X7AiAx65+nqAI54LndtVFnQZB6G/FVLkZH8y8V6R3cIoOQR4pUdfwQGd1iwyoXHJ4Qfw==
-
-gl-matrix@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/gl-matrix/-/gl-matrix-3.0.0.tgz#888301ac7650e148c3865370e13ec66d08a8381f"
-  integrity sha512-PD4mVH/C/Zs64kOozeFnKY8ybhgwxXXQYGWdB4h68krAHknWJgk9uKOn6z8YElh5//vs++90pb6csrTIDWnexA==
 
 glob-parent@^3.1.0:
   version "3.1.0"
@@ -3219,6 +3655,11 @@ globals@^11.1.0, globals@^11.7.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.10.0.tgz#1e09776dffda5e01816b3bb4077c8b59c24eaa50"
   integrity sha512-0GZF1RiPKU97IHUO5TORo9w1PwrH/NBPl+fS7oMLdaTRiYmYbwK4NWoZWrAdd0/abG9R2BU+OiwyQpTpE6pdfQ==
 
+globals@^9.18.0:
+  version "9.18.0"
+  resolved "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
+  integrity sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==
+
 globby@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-5.0.0.tgz#ebd84667ca0dbb330b99bcfc68eac2bc54370e0d"
@@ -3246,16 +3687,6 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.4
   version "4.1.15"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
   integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
-
-grid-index@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/grid-index/-/grid-index-1.1.0.tgz#97f8221edec1026c8377b86446a7c71e79522ea7"
-  integrity sha512-HZRwumpOGUrHyxO5bqKZL0B0GlUpwtCAzZ42sgxUPniu33R1LSFH5yrIcBCHjkctCAh3mtWKcKd9J4vDDdeVHA==
-
-hammerjs@^2.0.8:
-  version "2.0.8"
-  resolved "https://registry.yarnpkg.com/hammerjs/-/hammerjs-2.0.8.tgz#04ef77862cff2bb79d30f7692095930222bf60f1"
-  integrity sha1-BO93hiz/K7edMPdpIJWTAiK/YPE=
 
 has-ansi@^2.0.0:
   version "2.0.0"
@@ -3338,10 +3769,24 @@ highcharts-react-official@^2.0.0:
   resolved "https://registry.yarnpkg.com/highcharts-react-official/-/highcharts-react-official-2.0.0.tgz#3e4a8a2cd9a894a55f72ff7967b6573e47ec30c1"
   integrity sha512-pEf1HBCmkJlIY6lAkjKXjjxaqZWUwcNcKrEIM2CFhXtLcl5VntiSgiVXe/pkDXyZG94mM90c72Z+8rnJ8ua6Dw==
 
-highcharts@^7.0.2:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/highcharts/-/highcharts-7.0.3.tgz#0c8edb578bae28774b9f0d49cf1ae4887b126305"
-  integrity sha512-ubfHLDqKZkGLfDGWYPaa9txLwiJDSWphMZ15xdC0RKKKxZ2ZBc13+MjDfz5ARpYGQvCHmytGOGFUgRWEvkOhNA==
+highcharts-react@0.0.3:
+  version "0.0.3"
+  resolved "https://registry.npmjs.org/highcharts-react/-/highcharts-react-0.0.3.tgz#a5e0daf90139aa226b676770ab1831ebc84d2b9c"
+  integrity sha1-peDa+QE5qiJrZ2dwqxgx68hNK5w=
+  dependencies:
+    highcharts "^5.0.12"
+    react "^15.6.1"
+    react-dom "^15.6.1"
+
+highcharts@^5.0.12:
+  version "5.0.15"
+  resolved "https://registry.npmjs.org/highcharts/-/highcharts-5.0.15.tgz#a9af11538a85b85f300e66f7a0e048a7ef8ab381"
+  integrity sha512-+LTe57ntLyWgkjsHzLmvRspM3FVKtds7iDswOTwuTAmZD3FtG1I/DqHiVSRjX92RQmQMZ1M7dcoRb7T648m1xA==
+
+highcharts@^7.0.3:
+  version "7.1.2"
+  resolved "https://registry.npmjs.org/highcharts/-/highcharts-7.1.2.tgz#f337e75cf0614f58f87fb28fbab48e1096265b5d"
+  integrity sha512-diSTVxWKefQzShi22gaV63pdrIFlQAsTGe3f328Ur7cqBoYFvHMtiMP+q+VOFdM2mdGVtlUR0QQSxj62LLsPpg==
 
 hmac-drbg@^1.0.0:
   version "1.0.1"
@@ -3363,6 +3808,13 @@ hoist-non-react-statics@^3.2.1:
   integrity sha512-TFsu3TV3YLY+zFTZDrN8L2DTFanObwmBLpWvJs1qfUuEQ5bTAdFcwfx2T/bsCXfM9QHSLvjfP+nihEl0yvozxw==
   dependencies:
     react-is "^16.3.2"
+
+hoist-non-react-statics@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz#b09178f0122184fb95acf525daaecb4d8f45958b"
+  integrity sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==
+  dependencies:
+    react-is "^16.7.0"
 
 hosted-git-info@^2.1.4:
   version "2.7.1"
@@ -3440,7 +3892,12 @@ icss-utils@^2.1.0:
   dependencies:
     postcss "^6.0.1"
 
-ieee754@^1.1.4, ieee754@^1.1.6:
+ieee754@1.1.8:
+  version "1.1.8"
+  resolved "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
+  integrity sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=
+
+ieee754@^1.1.4:
   version "1.1.12"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.12.tgz#50bf24e5b9c8bb98af4964c941cdb0918da7b60b"
   integrity sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==
@@ -3548,7 +4005,7 @@ inquirer@^6.1.0:
     strip-ansi "^5.0.0"
     through "^2.3.6"
 
-invariant@^2.2.2:
+invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -3767,11 +4224,6 @@ is-windows@^1.0.2:
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
 
-isarray@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
-  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
-
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -3801,6 +4253,11 @@ isomorphic-fetch@^2.1.1:
   dependencies:
     node-fetch "^1.0.1"
     whatwg-fetch ">=0.10.0"
+
+jmespath@0.15.0:
+  version "0.15.0"
+  resolved "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
+  integrity sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=
 
 js-levenshtein@^1.1.3:
   version "1.1.6"
@@ -3965,11 +4422,6 @@ junk@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/junk/-/junk-1.0.3.tgz#87be63488649cbdca6f53ab39bec9ccd2347f592"
   integrity sha1-h75jSIZJy9ym9Tqzm+yczSNH9ZI=
-
-kdbush@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/kdbush/-/kdbush-3.0.0.tgz#f8484794d47004cc2d85ed3a79353dbe0abc2bf0"
-  integrity sha512-hRkd6/XW4HTsA9vjVpY9tuXJYLSlelnkTmVFu4M9/7MIYQtFcHpbugAU7UbOfjOiVSVYl2fqgBuJ32JUmRo5Ew==
 
 keycode@^2.1.9:
   version "2.2.0"
@@ -4155,36 +4607,6 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-mapbox-gl@~0.52.0:
-  version "0.52.0"
-  resolved "https://registry.yarnpkg.com/mapbox-gl/-/mapbox-gl-0.52.0.tgz#a43b61caa339ae28e43c87ecfbe9ce4032795859"
-  integrity sha512-jiZMGI7LjBNiSwYpFA3drzbZXrgEGERGJRpNS95t5BLZoc8Z+ggOOI1Fz2X+zLlh1j32iNDtf4j6En+caWwYiQ==
-  dependencies:
-    "@mapbox/geojson-types" "^1.0.2"
-    "@mapbox/jsonlint-lines-primitives" "^2.0.2"
-    "@mapbox/mapbox-gl-supported" "^1.4.0"
-    "@mapbox/point-geometry" "^0.1.0"
-    "@mapbox/tiny-sdf" "^1.1.0"
-    "@mapbox/unitbezier" "^0.0.0"
-    "@mapbox/vector-tile" "^1.3.1"
-    "@mapbox/whoots-js" "^3.1.0"
-    csscolorparser "~1.0.2"
-    earcut "^2.1.3"
-    esm "^3.0.84"
-    geojson-rewind "^0.3.0"
-    geojson-vt "^3.2.1"
-    gl-matrix "^2.6.1"
-    grid-index "^1.0.0"
-    minimist "0.0.8"
-    murmurhash-js "^1.0.0"
-    pbf "^3.0.5"
-    potpack "^1.0.1"
-    quickselect "^1.0.0"
-    rw "^1.3.3"
-    supercluster "^5.0.0"
-    tinyqueue "^1.1.0"
-    vt-pbf "^3.0.1"
-
 maximatch@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/maximatch/-/maximatch-0.1.0.tgz#86cd8d6b04c9f307c05a6b9419906d0360fb13a2"
@@ -4254,6 +4676,11 @@ miller-rabin@^4.0.0:
     bn.js "^4.0.0"
     brorand "^1.0.1"
 
+"mime-db@>= 1.40.0 < 2":
+  version "1.40.0"
+  resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz#a65057e998db090f732a68f6c276d387d4126c32"
+  integrity sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==
+
 mime-db@~1.37.0:
   version "1.37.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.37.0.tgz#0b6a0ce6fdbe9576e25f1f2d2fde8830dc0ad0d8"
@@ -4306,11 +4733,6 @@ minimatch@^3.0.0, minimatch@^3.0.3, minimatch@^3.0.4:
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
   dependencies:
     brace-expansion "^1.1.7"
-
-minimist@0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.5.tgz#d7aa327bcecf518f9106ac6b8f003fa3bcea8566"
-  integrity sha1-16oye87PUY+RBqxrjwA/o7zqhWY=
 
 minimist@0.0.8:
   version "0.0.8"
@@ -4385,14 +4807,6 @@ mixin-object@^2.0.1:
     for-in "^0.1.3"
     is-extendable "^0.1.1"
 
-mjolnir.js@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/mjolnir.js/-/mjolnir.js-2.0.3.tgz#2354d31bc966a13f18d3bc350d5491acfb562914"
-  integrity sha512-3AvoMwJCR3m9QQYzsE+D+LWZ9N2uWbl7prixSJGRZNOpaagRgiXJeVvDEHTiXAGmNhdn/VAtgWrx3lpdrj2sIQ==
-  dependencies:
-    "@babel/runtime" "^7.0.0"
-    hammerjs "^2.0.8"
-
 mkdirp-then@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mkdirp-then/-/mkdirp-then-1.2.0.tgz#a492c879ca4d873f5ee45008f8f55fd0150de3c5"
@@ -4446,11 +4860,6 @@ ms@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
   integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
-
-murmurhash-js@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/murmurhash-js/-/murmurhash-js-1.0.0.tgz#b06278e21fc6c37fa5313732b0412bcb6ae15f51"
-  integrity sha1-sGJ44h/Gw3+lMTcysEEry2rhX1E=
 
 mute-stream@0.0.7:
   version "0.0.7"
@@ -4507,6 +4916,11 @@ neo-async@^2.5.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.0.tgz#b9d15e4d71c6762908654b5183ed38b753340835"
   integrity sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==
+
+next-redux-wrapper@^3.0.0-alpha.1:
+  version "3.0.0-alpha.3"
+  resolved "https://registry.npmjs.org/next-redux-wrapper/-/next-redux-wrapper-3.0.0-alpha.3.tgz#3db44012e2e36e12977816cc8726a9e2d24a9c40"
+  integrity sha512-qFYQbba8u3kb71FYxOyyAg0cQ5fe9GAJVy52wuXPDEU6irGz7jOrj/8JYhFa9WJh5sSpEdnFK6vFyvihLltemw==
 
 next@^7.0.2:
   version "7.0.2"
@@ -4773,6 +5187,11 @@ on-finished@~2.3.0:
   dependencies:
     ee-first "1.1.1"
 
+on-headers@~1.0.2:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz#772b0ae6aaa525c399e489adfad90c403eb3c28f"
+  integrity sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==
+
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
@@ -4869,11 +5288,6 @@ pako@~1.0.5:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.8.tgz#6844890aab9c635af868ad5fecc62e8acbba3ea4"
   integrity sha512-6i0HVbUfcKaTv+EG8ZTr75az7GFXcLYk9UyLEg7Notv/Ma+z/UG3TCoz6GiNeOrn1E/e63I0X/Hpw18jHOTUnA==
-
-papaparse@^4.6.3:
-  version "4.6.3"
-  resolved "https://registry.yarnpkg.com/papaparse/-/papaparse-4.6.3.tgz#742e5eaaa97fa6c7e1358d2934d8f18f44aee781"
-  integrity sha512-LRq7BrHC2kHPBYSD50aKuw/B/dGcg29omyJbKWY3KsYUZU69RKwaBHu13jGmCYBtOc4odsLCrFyk6imfyNubJQ==
 
 parallel-transform@^1.1.0:
   version "1.1.0"
@@ -4985,14 +5399,6 @@ path-type@^2.0.0:
   integrity sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=
   dependencies:
     pify "^2.0.0"
-
-pbf@^3.0.5:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/pbf/-/pbf-3.1.0.tgz#f70004badcb281761eabb1e76c92f179f08189e9"
-  integrity sha512-/hYJmIsTmh7fMkHAWWXJ5b8IKLWdjdlAFb3IHkRBn1XUhIYBChVGfVwmHEAV3UfXTxsP/AKfYTXTS/dCPxJd5w==
-  dependencies:
-    ieee754 "^1.1.6"
-    resolve-protobuf-schema "^2.0.0"
 
 pbkdf2@^3.0.3:
   version "3.0.17"
@@ -5135,11 +5541,6 @@ postcss@^7.0.0:
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
-potpack@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/potpack/-/potpack-1.0.1.tgz#d1b1afd89e4c8f7762865ec30bd112ab767e2ebf"
-  integrity sha512-15vItUAbViaYrmaB/Pbw7z6qX2xENbFSTA7Ii4tgbPtasxm5v6ryKhKtL91tpWovDJzTiZqdwzhcFBCwiMVdVw==
-
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -5199,18 +5600,14 @@ prop-types@15.6.2, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.2:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-prop-types@^15.5.7:
-  version "15.7.1"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.1.tgz#2fa61e0a699d428b40320127733ee2931f05d9d1"
-  integrity sha512-f8Lku2z9kERjOCcnDOPm68EBJAO2K00Q5mSgPAUE/gJuBgsYLbVy6owSrtcHj90zt8PvW+z0qaIIgsIhHOa1Qw==
+prop-types@^15.5.10, prop-types@^15.7.2:
+  version "15.7.2"
+  resolved "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
   dependencies:
+    loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.8.1"
-
-protocol-buffers-schema@^3.3.1:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/protocol-buffers-schema/-/protocol-buffers-schema-3.3.2.tgz#00434f608b4e8df54c59e070efeefc37fb4bb859"
-  integrity sha512-Xdayp8sB/mU+sUV4G7ws8xtYMGdQnxbeIfLjyO9TZZRJdztBGhlmbI5x1qcY4TG5hBkIKGnc28i7nXxaugu88w==
 
 proxy-addr@~2.0.4:
   version "2.0.4"
@@ -5282,13 +5679,6 @@ punycode@^2.1.0:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-push-dir@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/push-dir/-/push-dir-0.4.1.tgz#29481eacd9c2106bbb7941db6d37d122a071ecb4"
-  integrity sha1-KUgerNnCEGu7eUHbbTfRIqBx7LQ=
-  dependencies:
-    minimist "^1.2.0"
-
 qs@6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
@@ -5303,11 +5693,6 @@ querystring@0.2.0, querystring@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
-
-quickselect@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/quickselect/-/quickselect-1.1.1.tgz#852e412ce418f237ad5b660d70cffac647ae94c2"
-  integrity sha512-qN0Gqdw4c4KGPsBOQafj6yj/PA6c/L63f6CaZ/DCF/xF4Esu3jVmKLUDYxghFx8Kb/O7y9tI7x2RjTSXwdK1iQ==
 
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5:
   version "2.0.6"
@@ -5349,6 +5734,16 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+react-dom@^15.6.1:
+  version "15.6.2"
+  resolved "https://registry.npmjs.org/react-dom/-/react-dom-15.6.2.tgz#41cfadf693b757faf2708443a1d1fd5a02bef730"
+  integrity sha1-Qc+t9pO3V/rycIRDodH9WgK+9zA=
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.0"
+    prop-types "^15.5.10"
+
 react-dom@^16.6.1:
   version "16.7.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.7.0.tgz#a17b2a7ca89ee7390bc1ed5eb81783c7461748b8"
@@ -5373,10 +5768,20 @@ react-event-listener@^0.6.2:
     prop-types "^15.6.0"
     warning "^4.0.1"
 
+react-fast-compare@^2.0.0:
+  version "2.0.4"
+  resolved "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
+  integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
+
 react-is@^16.3.2, react-is@^16.6.3:
   version "16.7.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.7.0.tgz#c1bd21c64f1f1364c6f70695ec02d69392f41bfa"
   integrity sha512-Z0VRQdF4NPDoI0tsXVMLkJLiwEBa+RP66g0xDHxgxysxSoCUccSten4RTF/UFvZF1dZvZ9Zu1sx+MDXwcOR34g==
+
+react-is@^16.7.0, react-is@^16.8.2:
+  version "16.8.6"
+  resolved "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
+  integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
 
 react-is@^16.8.1:
   version "16.8.1"
@@ -5399,22 +5804,22 @@ react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-react-map-gl@^4.0.9:
-  version "4.0.10"
-  resolved "https://registry.yarnpkg.com/react-map-gl/-/react-map-gl-4.0.10.tgz#f9338ea8258bfc29edd35e538400dfc71f210a60"
-  integrity sha512-QSg6BvhKkUc0zZnXWfxJ+W45AyskZnnaLNk1/Q/hQASTVhspmjme0FatvNMrFiN4ZPH7Mxta6exSsk1hMhnQyg==
-  dependencies:
-    "@babel/runtime" "^7.0.0"
-    mapbox-gl "~0.52.0"
-    mjolnir.js "^2.0.3"
-    prop-types "^15.5.7"
-    react-virtualized-auto-sizer "^1.0.2"
-    viewport-mercator-project "^6.1.0"
-
 react-moment@^0.8.4:
   version "0.8.4"
   resolved "https://registry.yarnpkg.com/react-moment/-/react-moment-0.8.4.tgz#18eb59e1541c8b216353e23c21e9db50e42e2edb"
   integrity sha512-QhI19OcfhiAn60/O6bMR0w8ApXrPFCjv6+eV0I/P9/AswzjgEAx4L7VxMBCpS/jrythLa12Q9v88req+ys4YpA==
+
+react-redux@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.npmjs.org/react-redux/-/react-redux-6.0.1.tgz#0d423e2c1cb10ada87293d47e7de7c329623ba4d"
+  integrity sha512-T52I52Kxhbqy/6TEfBv85rQSDz6+Y28V/pf52vDWs1YRXG19mcFOGfHnY2HsNFHyhP+ST34Aih98fvt6tqwVcQ==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    hoist-non-react-statics "^3.3.0"
+    invariant "^2.2.4"
+    loose-envify "^1.4.0"
+    prop-types "^15.7.2"
+    react-is "^16.8.2"
 
 react-request@^3.1.2:
   version "3.1.2"
@@ -5434,10 +5839,16 @@ react-transition-group@^2.2.1:
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
 
-react-virtualized-auto-sizer@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.2.tgz#a61dd4f756458bbf63bd895a92379f9b70f803bd"
-  integrity sha512-MYXhTY1BZpdJFjUovvYHVBmkq79szK/k7V3MO+36gJkWGkrXKtyr4vCPtpphaTLRAdDNoYEYFZWE8LjN+PIHNg==
+react@^15.6.1:
+  version "15.6.2"
+  resolved "https://registry.npmjs.org/react/-/react-15.6.2.tgz#dba0434ab439cfe82f108f0f511663908179aa72"
+  integrity sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=
+  dependencies:
+    create-react-class "^15.6.0"
+    fbjs "^0.8.9"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.0"
+    prop-types "^15.5.10"
 
 react@^16.6.1:
   version "16.7.0"
@@ -5479,16 +5890,6 @@ read-pkg@^2.0.0:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@~1.1.0:
-  version "1.1.14"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
-  integrity sha1-fPTFTvZI44EwhMY23SB54WbAgdk=
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "0.0.1"
-    string_decoder "~0.10.x"
-
 readdirp@^2.0.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-2.2.1.tgz#0e87622a3325aa33e892285caf8b4e846529a525"
@@ -5526,12 +5927,13 @@ recursive-copy@2.0.6:
     promise "^7.0.1"
     slash "^1.0.0"
 
-redeyed@~0.4.0:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/redeyed/-/redeyed-0.4.4.tgz#37e990a6f2b21b2a11c2e6a48fd4135698cba97f"
-  integrity sha1-N+mQpvKyGyoRwuakj9QTVpjLqX8=
+redux@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.npmjs.org/redux/-/redux-4.0.1.tgz#436cae6cc40fbe4727689d7c8fae44808f1bfef5"
+  integrity sha512-R7bAtSkk7nY6O/OYMVR9RiBI+XghjF9rlbl5806HJbQph0LJVHZrU5oaO4q70eUKiqMRqm4y07KLTlMZ2BlVmg==
   dependencies:
-    esprima "~1.0.4"
+    loose-envify "^1.4.0"
+    symbol-observable "^1.2.0"
 
 reflect.ownkeys@^0.2.0:
   version "0.2.0"
@@ -5565,6 +5967,20 @@ regenerator-runtime@^0.12.0:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
   integrity sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==
 
+regenerator-runtime@^0.13.2:
+  version "0.13.2"
+  resolved "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz#32e59c9a6fb9b1a4aff09b4930ca2d4477343447"
+  integrity sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==
+
+regenerator-transform@^0.10.0:
+  version "0.10.1"
+  resolved "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz#1e4996837231da8b7f3cf4114d71b5691a0680dd"
+  integrity sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==
+  dependencies:
+    babel-runtime "^6.18.0"
+    babel-types "^6.19.0"
+    private "^0.1.6"
+
 regenerator-transform@^0.13.3:
   version "0.13.3"
   resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.13.3.tgz#264bd9ff38a8ce24b06e0636496b2c856b57bcbb"
@@ -5589,6 +6005,15 @@ regexpu-core@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-1.0.0.tgz#86a763f58ee4d7c2f6b102e4764050de7ed90c6b"
   integrity sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=
+  dependencies:
+    regenerate "^1.2.1"
+    regjsgen "^0.2.0"
+    regjsparser "^0.1.4"
+
+regexpu-core@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz#49d038837b8dcf8bfa5b9a42139938e6ea2ae240"
+  integrity sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=
   dependencies:
     regenerate "^1.2.1"
     regjsgen "^0.2.0"
@@ -5660,13 +6085,6 @@ resolve-from@^4.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
 
-resolve-protobuf-schema@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz#9ca9a9e69cf192bbdaf1006ec1973948aa4a3758"
-  integrity sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==
-  dependencies:
-    protocol-buffers-schema "^3.3.1"
-
 resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
@@ -5728,7 +6146,7 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
-rw@1, rw@^1.3.3:
+rw@1:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/rw/-/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"
   integrity sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q=
@@ -5768,9 +6186,14 @@ sass-loader@6.0.6:
     lodash.tail "^4.1.1"
     pify "^3.0.0"
 
-sax@^1.2.4:
+sax@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
+  integrity sha1-e45lYZCyKOgaZq6nSEgNgozS03o=
+
+sax@>=0.6.0, sax@^1.2.4:
   version "1.2.4"
-  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+  resolved "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
 scheduler@^0.12.0:
@@ -5913,18 +6336,6 @@ shallow-clone@^0.1.2:
     kind-of "^2.0.1"
     lazy-cache "^0.2.3"
     mixin-object "^2.0.1"
-
-sharkdown@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/sharkdown/-/sharkdown-0.1.0.tgz#61d4fe529e75d02442127cc9234362265099214f"
-  integrity sha1-YdT+Up510CRCEnzJI0NiJlCZIU8=
-  dependencies:
-    cardinal "~0.4.2"
-    expect.js "~0.2.0"
-    minimist "0.0.5"
-    split "~0.2.10"
-    stream-spigot "~2.1.2"
-    through "~2.3.4"
 
 shebang-command@^1.2.0:
   version "1.2.0"
@@ -6081,13 +6492,6 @@ split-string@^3.0.1, split-string@^3.0.2:
   dependencies:
     extend-shallow "^3.0.0"
 
-split@~0.2.10:
-  version "0.2.10"
-  resolved "https://registry.yarnpkg.com/split/-/split-0.2.10.tgz#67097c601d697ce1368f418f06cd201cf0521a57"
-  integrity sha1-Zwl8YB1pfOE2j0GPBs0gHPBSGlc=
-  dependencies:
-    through "2"
-
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
@@ -6174,13 +6578,6 @@ stream-shift@^1.0.0:
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.0.tgz#d5c752825e5367e786f78e18e445ea223a155952"
   integrity sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=
 
-stream-spigot@~2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/stream-spigot/-/stream-spigot-2.1.2.tgz#7de145e819f8dd0db45090d13dcf73a8ed3cc035"
-  integrity sha1-feFF6Bn43Q20UJDRPc9zqO08wDU=
-  dependencies:
-    readable-stream "~1.1.0"
-
 string-hash@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/string-hash/-/string-hash-1.1.3.tgz#e8aafc0ac1855b4666929ed7dd1275df5d6c811b"
@@ -6209,11 +6606,6 @@ string_decoder@^1.0.0:
   integrity sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==
   dependencies:
     safe-buffer "~5.1.0"
-
-string_decoder@~0.10.x:
-  version "0.10.31"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
-  integrity sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=
 
 string_decoder@~1.1.1:
   version "1.1.1"
@@ -6277,13 +6669,6 @@ stylis@3.5.3:
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.3.tgz#99fdc46afba6af4deff570825994181a5e6ce546"
   integrity sha512-TxU0aAscJghF9I3V9q601xcK3Uw1JbXvpsBGj/HULqexKOKlOEzzlIpLFRbKkCK990ccuxfXUqmPbIIo7Fq/cQ==
 
-supercluster@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/supercluster/-/supercluster-5.0.0.tgz#2a5a9b1ffbd0d6180dea10039d78b5d95fdb8f27"
-  integrity sha512-9eeD5Q3908+tqdz+wYHHzi5mLKgnqtpO5mrjUfqr67UmGuOwBtVoQ9pJJrfcVHwMwC0wEBvfNRF9PgFOZgsOpw==
-  dependencies:
-    kdbush "^3.0.0"
-
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
@@ -6303,7 +6688,7 @@ supports-color@^6.1.0:
   dependencies:
     has-flag "^3.0.0"
 
-symbol-observable@1.2.0, symbol-observable@^1.0.4, symbol-observable@^1.1.0:
+symbol-observable@1.2.0, symbol-observable@^1.0.4, symbol-observable@^1.1.0, symbol-observable@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
   integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
@@ -6394,7 +6779,7 @@ through2@^2.0.0:
     readable-stream "~2.3.6"
     xtend "~4.0.1"
 
-through@2, through@^2.3.6, through@~2.3.4:
+through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
@@ -6405,11 +6790,6 @@ timers-browserify@^2.0.4:
   integrity sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==
   dependencies:
     setimmediate "^1.0.4"
-
-tinyqueue@^1.1.0:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/tinyqueue/-/tinyqueue-1.2.3.tgz#b6a61de23060584da29f82362e45df1ec7353f3d"
-  integrity sha512-Qz9RgWuO9l8lT+Y9xvbzhPT2efIUIFd69N7eF7tJ9lnQl0iLj1M7peK7IoUGZL9DJHw9XftqLreccfxcQgYLxA==
 
 tmp@^0.0.33:
   version "0.0.33"
@@ -6602,6 +6982,14 @@ urix@^0.1.0:
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
 
+url@0.10.3:
+  version "0.10.3"
+  resolved "https://registry.npmjs.org/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64"
+  integrity sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=
+  dependencies:
+    punycode "1.3.2"
+    querystring "0.2.0"
+
 url@0.11.0, url@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
@@ -6652,9 +7040,9 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
-uuid@^3.3.2:
+uuid@3.3.2, uuid@^3.3.2:
   version "3.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
+  resolved "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
 validate-npm-package-license@^3.0.1:
@@ -6670,13 +7058,285 @@ vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
 
-viewport-mercator-project@^6.1.0:
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/viewport-mercator-project/-/viewport-mercator-project-6.1.1.tgz#d7b2cb3cb772b819f1daab17cf4019102a9102a6"
-  integrity sha512-nI0GEmXnESwZxWSJuaQkdCnvOv6yckUfqqFbNB8KWVbQY3eUExVM4ZziqCVVs5mNznLjDF1auj6HLW5D5DKcng==
+victory-area@^32.2.3:
+  version "32.2.3"
+  resolved "https://registry.npmjs.org/victory-area/-/victory-area-32.2.3.tgz#0142ee68575ae065741094314f53e891622d10dd"
+  integrity sha512-KEFQLqr6c/a4/9ssTNxmJw+Ry+TADMY44IAvTxAuz7rxiDEq0G0TkBWxUKCp1hZ2mNLVQ5JKJ3CAk3pWu1usNw==
   dependencies:
-    "@babel/runtime" "^7.0.0"
-    gl-matrix "^3.0.0"
+    d3-shape "^1.2.0"
+    lodash "^4.17.5"
+    prop-types "^15.5.8"
+    victory-core "^32.2.3"
+
+victory-axis@^32.2.3:
+  version "32.2.3"
+  resolved "https://registry.npmjs.org/victory-axis/-/victory-axis-32.2.3.tgz#783915c44cdae1b1fd3913922ff86aa53f247406"
+  integrity sha512-DuxHlwmJzNxQ0I72zRJoe7VWE2us7SKToYmmbQ571ed8S75vJV9627C1zdg7Sb98/8AsQvjXShLK8gfp+fdABA==
+  dependencies:
+    lodash "^4.17.5"
+    prop-types "^15.5.8"
+    victory-core "^32.2.3"
+
+victory-bar@^32.2.3:
+  version "32.2.3"
+  resolved "https://registry.npmjs.org/victory-bar/-/victory-bar-32.2.3.tgz#64aa6dd29907299e793f976954e00874072f6f4f"
+  integrity sha512-SgzAsjcrRMBO3kbchbESxKLhjfALi8unjoC3vn4HDtBx9lK9T9xR1TOSgOlf+a9GXOBU+9QQR4QwdpImZkNueg==
+  dependencies:
+    d3-shape "^1.2.0"
+    lodash "^4.17.5"
+    prop-types "^15.5.8"
+    victory-core "^32.2.3"
+
+victory-box-plot@^32.2.3:
+  version "32.2.3"
+  resolved "https://registry.npmjs.org/victory-box-plot/-/victory-box-plot-32.2.3.tgz#0e42f41d0770cef688f2a90faa1e2976a1e4df1b"
+  integrity sha512-gzPsDBR0Gmyu695slYeeWHdmyyOrbSMGcJrlqeFG1AgXRrPHk7qBBhey8p2skOSrsNAKzHNnVkH9qnX/ywf8ag==
+  dependencies:
+    d3-array "^1.2.0"
+    lodash "^4.17.5"
+    prop-types "^15.5.8"
+    victory-core "^32.2.3"
+
+victory-brush-container@^32.2.3:
+  version "32.2.3"
+  resolved "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-32.2.3.tgz#abe84830f27dd0d20f35941d38f6bb55b1c74e4a"
+  integrity sha512-l4c3Nb7gVsGpOGcnLODULO5Yf6521aHe1ZRo9C4ScEUImwNXhoy9g+QoDVFi+SM8WbOTJd4SMGyngStZ87pLGg==
+  dependencies:
+    lodash "^4.17.5"
+    prop-types "^15.5.8"
+    victory-core "^32.2.3"
+
+victory-brush-line@^32.2.3:
+  version "32.2.3"
+  resolved "https://registry.npmjs.org/victory-brush-line/-/victory-brush-line-32.2.3.tgz#f1341da0ce103ebe1b14bacbbe658c24f4b5f64c"
+  integrity sha512-EKcaUddQ9+BFSzjnyFZG4d8VrAK91T63m+TWB9v0Si4S8UnlP8Rsu1EaVd28eGZhgXgJ5nZk1bGsIczOqQnCnQ==
+  dependencies:
+    lodash "^4.17.5"
+    prop-types "^15.5.8"
+    victory-core "^32.2.3"
+
+victory-candlestick@^32.2.3:
+  version "32.2.3"
+  resolved "https://registry.npmjs.org/victory-candlestick/-/victory-candlestick-32.2.3.tgz#5cb9227a31f077ac37046ecbb1bf0b66b3e0371b"
+  integrity sha512-0KW7U1304ZYSI/yGuTPftz2qTJgwCljBFyPD6jo7M+y73o2WTJDLhnZb6Svs5taKmldVsvLw1P9/KZr6rfWkTg==
+  dependencies:
+    lodash "^4.17.5"
+    prop-types "^15.5.8"
+    victory-core "^32.2.3"
+
+victory-chart@^32.2.3:
+  version "32.2.3"
+  resolved "https://registry.npmjs.org/victory-chart/-/victory-chart-32.2.3.tgz#c191f6cf37fe3ce27d6b05c9c6e16c233d95358f"
+  integrity sha512-ECZrYcTK7Ze1156lyeD5Sjj/PrahtQKy+c++egmdUnmYZuYKYfg4WUaiTFGk6+XoYT0tUAxiyhfqWbzP4gSCSQ==
+  dependencies:
+    lodash "^4.17.5"
+    prop-types "^15.5.8"
+    react-fast-compare "^2.0.0"
+    victory-axis "^32.2.3"
+    victory-core "^32.2.3"
+    victory-polar-axis "^32.2.3"
+    victory-shared-events "^32.2.3"
+
+victory-core@^32.2.3:
+  version "32.2.3"
+  resolved "https://registry.npmjs.org/victory-core/-/victory-core-32.2.3.tgz#15e2c5c9d616c79dcb58e84ccecae91acc82e72d"
+  integrity sha512-JFASPSrVH9lXwD5CdL59fEVc68waa3FDjqhukKhHsHeH7uDHaIr+3QKcWC36fBt5lzrymDWe5bEeWFWLWQeufw==
+  dependencies:
+    d3-ease "^1.0.0"
+    d3-interpolate "^1.1.1"
+    d3-scale "^1.0.0"
+    d3-shape "^1.2.0"
+    d3-timer "^1.0.0"
+    lodash "^4.17.5"
+    prop-types "^15.5.8"
+    react-fast-compare "^2.0.0"
+
+victory-create-container@^32.2.3:
+  version "32.2.3"
+  resolved "https://registry.npmjs.org/victory-create-container/-/victory-create-container-32.2.3.tgz#e594f4775e44ac04f002200e007bb1cde9280ce6"
+  integrity sha512-RoZdlHSK3xl8r2oCPLpxW+GsYz5wfKmtOokBJQ191Lr7LDpuct26SEADhIoiCqJUfzATpJiHWN5xBOyF0d4Eww==
+  dependencies:
+    lodash "^4.17.5"
+    victory-brush-container "^32.2.3"
+    victory-core "^32.2.3"
+    victory-cursor-container "^32.2.3"
+    victory-selection-container "^32.2.3"
+    victory-voronoi-container "^32.2.3"
+    victory-zoom-container "^32.2.3"
+
+victory-cursor-container@^32.2.3:
+  version "32.2.3"
+  resolved "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-32.2.3.tgz#14eac1f97a8eb6382ee6b7450e3536332190d496"
+  integrity sha512-7qAFSscMm5Ze6C8EoWuPk0VVfMpth0NTpsCFgqZ3BWHVBbCUIrU/6mq395pjDIyiDExFAFZrV5puo2gcadWAcw==
+  dependencies:
+    lodash "^4.17.5"
+    prop-types "^15.5.8"
+    victory-core "^32.2.3"
+
+victory-errorbar@^32.2.3:
+  version "32.2.3"
+  resolved "https://registry.npmjs.org/victory-errorbar/-/victory-errorbar-32.2.3.tgz#9ce5020529246cda8a6c8808b62493ae450c0199"
+  integrity sha512-ZEDLceGUGbeQYIxHDS6zbHz18bKMA81UCWJ9kxmTHlIywOLuZEXZc1pKDzfV/YX634Wh5zVYrsTnG04WupwjxA==
+  dependencies:
+    lodash "^4.17.5"
+    prop-types "^15.5.8"
+    victory-core "^32.2.3"
+
+victory-group@^32.2.3:
+  version "32.2.3"
+  resolved "https://registry.npmjs.org/victory-group/-/victory-group-32.2.3.tgz#b612a06959af2e52e5daf6f515d066a1381ca2ae"
+  integrity sha512-w/vJnbSedFs8s/yeMOe1DlELKoWNpN5mEnUYjWEJbVq59uuvdKSE6kek/P/0SRvI3OycGP36U1emYVIYMfkfng==
+  dependencies:
+    lodash "^4.17.5"
+    prop-types "^15.5.8"
+    react-fast-compare "^2.0.0"
+    victory-core "^32.2.3"
+
+victory-legend@^32.2.3:
+  version "32.2.3"
+  resolved "https://registry.npmjs.org/victory-legend/-/victory-legend-32.2.3.tgz#6802d45b1410f94998c11fc8573a3da420c2d6f1"
+  integrity sha512-MA6WTXpT6/b9GLVzZAS0b1vvLjjrHj5iEqYD4OUCrEUctZWKZ0z3z6b0XQ2buewDFavvD6tMlqJBGwCY7byKJA==
+  dependencies:
+    lodash "^4.17.5"
+    prop-types "^15.5.8"
+    victory-core "^32.2.3"
+
+victory-line@^32.2.3:
+  version "32.2.3"
+  resolved "https://registry.npmjs.org/victory-line/-/victory-line-32.2.3.tgz#5d974ec5d28df02d80cd6d0ced1ad48bd23d6f60"
+  integrity sha512-xnuR0nt7kNEGXJzPw3J4v3yfnG4Me0QJ7IHA1RKYOIggYrVl6y+tHPwAQIWrq2F1OJQ5yl4K+ypFKLS5MDtTrQ==
+  dependencies:
+    d3-shape "^1.2.0"
+    lodash "^4.17.5"
+    prop-types "^15.5.8"
+    victory-core "^32.2.3"
+
+victory-pie@^32.2.3:
+  version "32.2.3"
+  resolved "https://registry.npmjs.org/victory-pie/-/victory-pie-32.2.3.tgz#2e2f24d670edafe0186ed6210b1327e458f5867a"
+  integrity sha512-JHustLMDwfzSOoNSBzdWNezZIUH9YmF1yWPXqtnGn0bgeDQeNrr8QmwATdJuz1DT+nZTV897uBwAiHVTvoX5Yg==
+  dependencies:
+    d3-shape "^1.0.0"
+    lodash "^4.17.5"
+    prop-types "^15.5.8"
+    victory-core "^32.2.3"
+
+victory-polar-axis@^32.2.3:
+  version "32.2.3"
+  resolved "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-32.2.3.tgz#d772ba24c7654e87709727779bdf925d4b49c285"
+  integrity sha512-jAtB0ic80P3NaM3eaFqRaxT5UVL9SftyYuK+D18s4E2QQQdeED/W8BLmJxh8Sdnun6CZ2iTadrcudA8nVN2QvQ==
+  dependencies:
+    lodash "^4.17.5"
+    prop-types "^15.5.8"
+    victory-core "^32.2.3"
+
+victory-scatter@^32.2.3:
+  version "32.2.3"
+  resolved "https://registry.npmjs.org/victory-scatter/-/victory-scatter-32.2.3.tgz#7a7181db7166f94ecdd3edb60ffe6aea4feb904f"
+  integrity sha512-LLSHNUHujEuW1eC/PU2zoga6QWEHp7RmvERHdhRcoSD6V448iLIG1ow+ikHmoa+mHay67lximnL+aE/lFamSHQ==
+  dependencies:
+    lodash "^4.17.5"
+    prop-types "^15.5.8"
+    victory-core "^32.2.3"
+
+victory-selection-container@^32.2.3:
+  version "32.2.3"
+  resolved "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-32.2.3.tgz#d2ddc126f1a025a82eaeb6ebf7da8e5125096635"
+  integrity sha512-8dXw90iLQc9EZPzmput+9XgmCqUaNLWaG9wYzyXVLs4Y9sSEfUcdTyeQc0vvpN3QMag1r03/yxY2ZCGzpTf1gQ==
+  dependencies:
+    lodash "^4.17.5"
+    prop-types "^15.5.8"
+    victory-core "^32.2.3"
+
+victory-shared-events@^32.2.3:
+  version "32.2.3"
+  resolved "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-32.2.3.tgz#748020fa79905929c8c1324d6aaddc6b518d421c"
+  integrity sha512-bTkaGZhXKPnpA6e7m3gw4wkywpPd5tBoHV7MUjrpbYkupIPnju3ltQBfqfROVghx4Et3NnffGbjHV8nyuDdmsQ==
+  dependencies:
+    lodash "^4.17.5"
+    prop-types "^15.5.8"
+    react-fast-compare "^2.0.0"
+    victory-core "^32.2.3"
+
+victory-stack@^32.2.3:
+  version "32.2.3"
+  resolved "https://registry.npmjs.org/victory-stack/-/victory-stack-32.2.3.tgz#3142a3b44810e44bdc988a2f26ba72ad0245bca2"
+  integrity sha512-KjD1HvGmHaAvP5IYPVkKtjepLvkXbZkyoKPOwWpATkuQ0wYoKh+fyH00wtFyC4AaGM9jKX/jcm1XCwU7xXdP0Q==
+  dependencies:
+    lodash "^4.17.5"
+    prop-types "^15.5.8"
+    react-fast-compare "^2.0.0"
+    victory-core "^32.2.3"
+
+victory-tooltip@^32.2.3:
+  version "32.2.3"
+  resolved "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-32.2.3.tgz#2e37bb69175c1e26667f2cc896e487c8c164ba68"
+  integrity sha512-pyJr4gs9/X3NhgJn09sllMqQyqCnxMxkk5Dn2rB/YyeHvAmfLxrvF0uVBg4ptHHmkrDdxZKpT2AvuGHtR2yl3Q==
+  dependencies:
+    lodash "^4.17.5"
+    prop-types "^15.5.8"
+    victory-core "^32.2.3"
+
+victory-voronoi-container@^32.2.3:
+  version "32.2.3"
+  resolved "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-32.2.3.tgz#d4d15670bb9cb2c408451e6c95140cf459cb786f"
+  integrity sha512-sMrVF2ybES6Ed9YMjzURGOqKh/MLKCuQrzUZCTBRxNbhXdptjBxaX5JUaLPenjSy1b9m83tvFsc9XYKKSuZxKw==
+  dependencies:
+    d3-voronoi "^1.1.2"
+    lodash "^4.17.5"
+    prop-types "^15.5.8"
+    victory-core "^32.2.3"
+    victory-tooltip "^32.2.3"
+
+victory-voronoi@^32.2.3:
+  version "32.2.3"
+  resolved "https://registry.npmjs.org/victory-voronoi/-/victory-voronoi-32.2.3.tgz#525cdca6a432e7e7315a01889bd875548d66c7cb"
+  integrity sha512-DUJp/seuhM94ETt/EsP8mEEWkfQvc8P8S/70RTkcW6Xrf5sz6aBP1RdiFS8nEB+0qCgP7deUUvxjeg1VeXnNeQ==
+  dependencies:
+    d3-voronoi "^1.1.2"
+    lodash "^4.17.5"
+    prop-types "^15.5.8"
+    victory-core "^32.2.3"
+
+victory-zoom-container@^32.2.3:
+  version "32.2.3"
+  resolved "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-32.2.3.tgz#1bcd931532ccbc6a47a7de6ce99f254935864301"
+  integrity sha512-mSx6scjnFB4zfNObyQls450pUYi6ZcRz9+ijGlXfa1uZUkEaIqFAxE41Ne0JUoclmWrQEHUNpnH8U9K4XjbZ0Q==
+  dependencies:
+    lodash "^4.17.5"
+    prop-types "^15.5.8"
+    victory-core "^32.2.3"
+
+victory@^32.1.0:
+  version "32.2.3"
+  resolved "https://registry.npmjs.org/victory/-/victory-32.2.3.tgz#64d09ac1d31be57616f89c16f76cc3c49f93942e"
+  integrity sha512-1jtZHHdQsHLcOJRRszLcKvigcz8KgQ1n8S+gK1QLh8f+TJ5nFtlDA8BXCgAghJq4X6WH9YOh94AO+9gkg+hHqw==
+  dependencies:
+    victory-area "^32.2.3"
+    victory-axis "^32.2.3"
+    victory-bar "^32.2.3"
+    victory-box-plot "^32.2.3"
+    victory-brush-container "^32.2.3"
+    victory-brush-line "^32.2.3"
+    victory-candlestick "^32.2.3"
+    victory-chart "^32.2.3"
+    victory-core "^32.2.3"
+    victory-create-container "^32.2.3"
+    victory-cursor-container "^32.2.3"
+    victory-errorbar "^32.2.3"
+    victory-group "^32.2.3"
+    victory-legend "^32.2.3"
+    victory-line "^32.2.3"
+    victory-pie "^32.2.3"
+    victory-polar-axis "^32.2.3"
+    victory-scatter "^32.2.3"
+    victory-selection-container "^32.2.3"
+    victory-shared-events "^32.2.3"
+    victory-stack "^32.2.3"
+    victory-tooltip "^32.2.3"
+    victory-voronoi "^32.2.3"
+    victory-voronoi-container "^32.2.3"
+    victory-zoom-container "^32.2.3"
 
 vm-browserify@0.0.4:
   version "0.0.4"
@@ -6684,15 +7344,6 @@ vm-browserify@0.0.4:
   integrity sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=
   dependencies:
     indexof "0.0.1"
-
-vt-pbf@^3.0.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/vt-pbf/-/vt-pbf-3.1.1.tgz#b0f627e39a10ce91d943b898ed2363d21899fb82"
-  integrity sha512-pHjWdrIoxurpmTcbfBWXaPwSmtPAHS105253P1qyEfSTV2HJddqjM+kIHquaT/L6lVJIk9ltTGc0IxR/G47hYA==
-  dependencies:
-    "@mapbox/point-geometry" "0.1.0"
-    "@mapbox/vector-tile" "^1.3.1"
-    pbf "^3.0.5"
 
 warning@^3.0.0:
   version "3.0.0"
@@ -6814,11 +7465,6 @@ webpackbar@2.6.3:
     std-env "^1.3.1"
     table "^4.0.3"
 
-wgs84@0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/wgs84/-/wgs84-0.0.0.tgz#34fdc555917b6e57cf2a282ed043710c049cdc76"
-  integrity sha1-NP3FVZF7blfPKigu0ENxDASc3HY=
-
 whatwg-fetch@>=0.10.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
@@ -6881,6 +7527,19 @@ write@^0.2.1:
   integrity sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=
   dependencies:
     mkdirp "^0.5.1"
+
+xml2js@0.4.19:
+  version "0.4.19"
+  resolved "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
+  integrity sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~9.0.1"
+
+xmlbuilder@~9.0.1:
+  version "9.0.7"
+  resolved "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
+  integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
 
 xmlhttprequest@1:
   version "1.8.0"


### PR DESCRIPTION
Linter is back in use now. You can use `npm run lint`. It is also included on `npm start` and `npm build`.

Added a few rule exceptions for now. I was having difficulty with the linter and aliases so they are just ignored for now.
Also, proptypes validation is being ignored for the time being as well.

Created a `/models` directory for shared Proptype models.

Cleaned up a lot of the errors that show up in the browser console.