### PR TITLE
Fix Line filter

### DIFF
--- a/components/scorecards/Comparison.jsx
+++ b/components/scorecards/Comparison.jsx
@@ -6,36 +6,31 @@ import {
 import Circle from '~/components/Circle';
 import { withStyles } from '@material-ui/core/styles';
 
-const styles = theme => ({
+const styles = () => ({
   performer: {
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
     flexDirection: 'row',
     marginBottom: 10,
-    width: '100%'
-  }
+    width: '100%',
+  },
 });
 
-const Comparison = (props) => {
-  const {
-    classes, comparisons
-  } = props;
-  const list = comparisons.map((comparison, i) => {
-    return(
-      <Grid key={i} item xs={12}>
-        <Typography color="textPrimary" align="center">
+const Comparison = ({ classes, comparisons }) => {
+  const list = comparisons.map((comparison, i) => (
+    <Grid key={i} item xs={12}>
+      <Typography color="textPrimary" align="center">
         {comparison.title}
+      </Typography>
+      <div className={classes.performer}>
+        <Circle color={comparison.color} />
+        <Typography color="textSecondary" style={{ marginLeft: 10 }} component="h3">
+          {comparison.text}
         </Typography>
-        <div className={classes.performer}>
-          <Circle color={comparison.color} />
-          <Typography color="textSecondary" style={{ marginLeft: 10 }} component="h3">
-            {comparison.text}
-          </Typography>
-        </div>
-      </Grid>
-    );
-  });
+      </div>
+    </Grid>
+  ));
 
   return (
     <Fragment>

--- a/components/scorecards/PerformanceScoreCard.jsx
+++ b/components/scorecards/PerformanceScoreCard.jsx
@@ -5,9 +5,7 @@ import {
   Divider,
 } from '@material-ui/core';
 import { withStyles } from '@material-ui/core/styles';
-import TooltipCustom from '~/components/TooltipCustom';
 import OnTimePie from '~/components/charts/OnTimePie';
-import Circle from '~/components/Circle';
 import { linesByName, linesById } from '~/helpers/LineInfo';
 import ScoreCard from './ScoreCard';
 import Comparison from './Comparison';
@@ -20,10 +18,10 @@ const styles = theme => ({
   }
 });
 
-const PerformanceScoreCard = (props) => {
-  const {
-    classes, data, currentLine, arrivalWindow, formattedLineData, width,
-  } = props;
+const PerformanceScoreCard = ({
+  classes, data, currentLine, arrivalWindow, formattedLineData, width,
+}) => {
+  const showComparison = currentLine === 'All';
   const lineId = linesByName[currentLine];
   const scoreData = lineId && lineId.id
     ? formattedLineData[formattedLineData.length - 1][`${lineId.id}_lametro-rail`]
@@ -37,41 +35,44 @@ const PerformanceScoreCard = (props) => {
   )
   / 10;
   const tooltip = {
-    title: "Performance Score",
+    title: 'Performance Score',
     content: `This figure is based on ${scoreData.total_arrivals_analyzed} train arrivals estimated so far out of ${scoreData.total_scheduled_arrivals} scheduled for today (${ percentAnalyzed } %). It includes trains both running ahead and behind schedule (early and late).`
   };
 
   const title = 'On-Time Performance';
+  const mostReliable = showComparison
+    ? {
+      title: 'Most Reliable',
+      color: linesById[scoreData.most_reliable[arrivalWindow].line.slice(0, 3)].color,
+      text: (
+        <Fragment>
+          {linesById[scoreData.most_reliable[arrivalWindow].line.slice(0, 3)].name}
+          {' Line '}
+          {(scoreData.most_reliable[arrivalWindow].percent_ontime * 100).toFixed(1)}
+          {'% on-time'}
+        </Fragment>
+      )
+    }
+    : null;
 
-  const mostReliable = {
-    title: 'Most Reliable',
-    color: linesById[scoreData.most_reliable[arrivalWindow].line.slice(0, 3)].color,
-    text: (
-      <Fragment>
-        {linesById[scoreData.most_reliable[arrivalWindow].line.slice(0, 3)].name}
-        {' Line '}
-        {(scoreData.most_reliable[arrivalWindow].percent_ontime * 100).toFixed(1)}
-        {'% on-time'}
-      </Fragment>
-    )
-  };
-
-  const leastReliable = {
-    title: 'Least Reliable',
-    color: linesById[scoreData.least_reliable[arrivalWindow].line.slice(0, 3)].color,
-    text: (
-      <Fragment>
-        {linesById[scoreData.least_reliable[arrivalWindow].line.slice(0, 3)].name}
-        {' Line '}
-        {(scoreData.least_reliable[arrivalWindow].percent_ontime * 100).toFixed(1)}
-        {'% on-time'}
-      </Fragment>
-    )
-  };
+  const leastReliable = showComparison
+    ? {
+      title: 'Least Reliable',
+      color: linesById[scoreData.least_reliable[arrivalWindow].line.slice(0, 3)].color,
+      text: (
+        <Fragment>
+          {linesById[scoreData.least_reliable[arrivalWindow].line.slice(0, 3)].name}
+          {' Line '}
+          {(scoreData.least_reliable[arrivalWindow].percent_ontime * 100).toFixed(1)}
+          {'% on-time'}
+        </Fragment>
+      )
+    }
+    : null;
 
   const content = (
-    <Grid container item justify="center" alignItems="center" xs={12} >
-      <Grid item xs={6} md={4} >
+    <Grid container item justify="center" alignItems="center" xs={12}>
+      <Grid item xs={6} md={4}>
         <OnTimePie
           bins={scoreData.ontime}
           total={scoreData.total_arrivals_analyzed}
@@ -91,7 +92,7 @@ const PerformanceScoreCard = (props) => {
         </Typography>
       </Grid>
       <Divider light variant="middle" className={classes.separator} />
-      <Comparison comparisons={[mostReliable, leastReliable]} />
+      {showComparison && <Comparison comparisons={[mostReliable, leastReliable]} />}
     </Grid>
   );
 

--- a/components/scorecards/WaitTimeScoreCard.jsx
+++ b/components/scorecards/WaitTimeScoreCard.jsx
@@ -5,7 +5,6 @@ import {
   Divider,
 } from '@material-ui/core';
 import { withStyles } from '@material-ui/core/styles';
-import Circle from '~/components/Circle';
 import { linesByName, linesById } from '~/helpers/LineInfo';
 import ScoreCard from './ScoreCard';
 import Comparison from './Comparison';
@@ -17,53 +16,56 @@ const styles = theme => ({
   },
 });
 
-const WaitTimeScoreCard = (props) => {
-  const {
-    classes,
-    data,
-    currentLine,
-    formattedLineData,
-    width,
-  } = props;
+const WaitTimeScoreCard = ({
+  classes,
+  data,
+  currentLine,
+  formattedLineData,
+  width,
+}) => {
+  const showComparison = currentLine === 'All';
 
-  const lineId = linesByName[currentLine]
-  ;
+  const lineId = linesByName[currentLine];
   const waitData = lineId && lineId.id
     ? formattedLineData[formattedLineData.length - 1][`${lineId.id}_lametro-rail`]
     : data;
 
   const tooltip = {
-    title: "Average Wait Time",
-    content: "This is an average over all stop intervals measured for the day so far. Obviously, this interval should be split by time of day since trains run more frequently during peak times. Feature coming soon!"
+    title: 'Average Wait Time',
+    content: 'This is an average over all stop intervals measured for the day so far. Obviously, this interval should be split by time of day since trains run more frequently during peak times. Feature coming soon!'
   };
 
   const title = 'Average Wait Time';
 
-  const mostFrequent = {
-    title: 'Most Frequent',
-    color: linesById[waitData.most_frequent.name].color,
-    text: (
-      <Fragment>
-      {linesById[waitData.most_frequent.name].name}
-      {' Line every '}
-      {Math.round(waitData.most_frequent.mean_time_between / 60)}
-      {' minutes'}
-      </Fragment>
-    )
-  };
+  const mostFrequent = showComparison
+    ? {
+      title: 'Most Frequent',
+      color: linesById[waitData.most_frequent.name].color,
+      text: (
+        <Fragment>
+          {linesById[waitData.most_frequent.name].name}
+          {' Line every '}
+          {Math.round(waitData.most_frequent.mean_time_between / 60)}
+          {' minutes'}
+        </Fragment>
+      )
+    }
+    : null;
 
-  const leastFrequent = {
-    title: 'Least Frequent',
-    color: linesById[waitData.least_frequent.name].color,
-    text: (
-      <Fragment>
-      {linesById[waitData.least_frequent.name].name}
-      {' Line every '}
-      {Math.round(waitData.least_frequent.mean_time_between / 60)}
-      {' minutes'}
-      </Fragment>
-    )
-  };
+  const leastFrequent = showComparison
+    ? {
+      title: 'Least Frequent',
+      color: linesById[waitData.least_frequent.name].color,
+      text: (
+        <Fragment>
+          {linesById[waitData.least_frequent.name].name}
+          {' Line every '}
+          {Math.round(waitData.least_frequent.mean_time_between / 60)}
+          {' minutes'}
+        </Fragment>
+      )
+    }
+    : null;
 
   const content = (
     <Fragment>
@@ -88,7 +90,7 @@ const WaitTimeScoreCard = (props) => {
         </Typography>
       </Grid>
       <Divider light variant="middle" className={classes.separator} />
-      <Comparison comparisons={[mostFrequent, leastFrequent]} />
+      {showComparison && <Comparison comparisons={[mostFrequent, leastFrequent]} />}
     </Fragment>
   );
 


### PR DESCRIPTION
Fixes issues #34 of line filters not working by putting in a check on the comparison data if the Filter is for all lines or not.
Some minor linting too.


Right now we have 2 filters for a line in the filter panel card and the history card. How should we resolve this?